### PR TITLE
feat: support category hooks & meta info

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,16 +6,16 @@ import { getHookItems } from '../src/utils';
 
 export default async () => {
   const hookItems = await getHookItems();
-  const sidebarHookItems = hookItems.reduce<DefaultTheme.SidebarItem[]>((acc, item) => {
-    const category = acc.find((group) => group.text === item.category);
+  const sidebarHookItems = hookItems.reduce<DefaultTheme.SidebarItem[]>((categoryItems, hookItem) => {
+    const category = categoryItems.find((group) => group.text === hookItem.category);
 
     if (!category) {
-      acc.push({ text: item.category, items: [item] });
+      categoryItems.push({ text: hookItem.category, items: [hookItem] });
     } else {
-      category.items?.push(item);
+      category.items!.push(hookItem);
     }
 
-    return acc;
+    return categoryItems;
   }, []);
   const homePageFeatures = hookItems.map((item) => ({
     title: item.text,

--- a/docs/functions/hooks/[name].md
+++ b/docs/functions/hooks/[name].md
@@ -1,10 +1,13 @@
 <script setup>
+import Meta from '../../src/components/meta.vue'
 import Api from '../../src/components/api.vue'
 import Demo from '../../src/components/demo.vue'
 import Contributors from '../../src/components/contributors.vue'
 </script>
 
 # {{ $params.name }}
+
+<Meta :last-modified="$params.lastModified" :category="$params.category" />
 
 {{ $params.description }}
 

--- a/docs/functions/hooks/[name].paths.ts
+++ b/docs/functions/hooks/[name].paths.ts
@@ -26,7 +26,7 @@ export default {
             id: hook,
             name: hook,
             description: jsdoc.description.description,
-            category: jsdoc.category?.name || 'Hooks',
+            category: jsdoc.category?.name,
             lastModified: stats.mtime.getTime(),
             usage: jsdoc.usage.description,
             apiParameters: jsdoc.apiParameters

--- a/docs/functions/hooks/[name].paths.ts
+++ b/docs/functions/hooks/[name].paths.ts
@@ -6,8 +6,8 @@ export default {
 
     const params = await Promise.all(
       hooks.map(async (hook) => {
-        const file = await getHookFile(hook);
-        const jsdocMatch = matchJsdoc(file);
+        const { content, stats } = await getHookFile(hook);
+        const jsdocMatch = matchJsdoc(content);
 
         if (!jsdocMatch) {
           console.error(`No jsdoc comment found for ${hook}`);
@@ -26,6 +26,8 @@ export default {
             id: hook,
             name: hook,
             description: jsdoc.description.description,
+            category: jsdoc.category?.name || 'Hooks',
+            lastModified: stats.mtime.getTime(),
             usage: jsdoc.usage.description,
             apiParameters: jsdoc.apiParameters
           }

--- a/docs/src/components/meta.vue
+++ b/docs/src/components/meta.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   }
 });
 
-function timeAgo (timestamp, locale = 'en') {
+const timeAgo = (timestamp, locale = 'en') => {
   let value;
   const diff = Math.floor((new Date().getTime() - timestamp) / 1000);
   const minutes = Math.floor(diff / 60);
@@ -38,11 +38,11 @@ function timeAgo (timestamp, locale = 'en') {
 <template>
   <div class="meta">
     <template v-if="category">
-      <div> Category </div>
-      <div>{{ category }}</div>
+      <div>Category</div>
+      <div><code>{{ category }}</code></div>
     </template>
     <template v-if="lastModified">
-      <div> Last Changed </div>
+      <div>Last Changed</div>
       <div>{{ timeAgo(lastModified) }}</div>
     </template>
   </div>

--- a/docs/src/components/meta.vue
+++ b/docs/src/components/meta.vue
@@ -1,0 +1,62 @@
+<script setup>
+const props = defineProps({
+  lastModified: {
+    type: Number
+  },
+  category: {
+    type: String
+  }
+});
+
+function timeAgo (timestamp, locale = 'en') {
+  let value;
+  const diff = Math.floor((new Date().getTime() - timestamp) / 1000);
+  const minutes = Math.floor(diff / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(months / 12);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  if (years > 0) {
+    value = rtf.format(0 - years, "year");
+  } else if (months > 0) {
+    value = rtf.format(0 - months, "month");
+  } else if (days > 0) {
+    value = rtf.format(0 - days, "day");
+  } else if (hours > 0) {
+    value = rtf.format(0 - hours, "hour");
+  } else if (minutes > 0) {
+    value = rtf.format(0 - minutes, "minute");
+  } else {
+    value = rtf.format(0 - diff, "second");
+  }
+  return value;
+}
+</script>
+
+<template>
+  <div class="meta">
+    <template v-if="category">
+      <div> Category </div>
+      <div>{{ category }}</div>
+    </template>
+    <template v-if="lastModified">
+      <div> Last Changed </div>
+      <div>{{ timeAgo(lastModified) }}</div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.meta {
+  font-size: .875rem;
+  line-height: 1.25rem;
+  display: grid;
+  grid-template-columns: 100px auto;
+  gap: .5rem;
+  align-items: flex-start;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+}
+</style>

--- a/docs/src/utils/hooks/getHookFile.ts
+++ b/docs/src/utils/hooks/getHookFile.ts
@@ -2,8 +2,12 @@ import fs from 'node:fs';
 
 export const getHookFile = async (name: string) => {
   try {
-    const fileContent = await fs.promises.readFile(`./src/hooks/${name}/${name}.ts`, 'utf-8');
-    return fileContent;
+    const filePath = `./src/hooks/${name}/${name}.ts`;
+
+    const stats = await fs.promises.stat(filePath);
+    const content = await fs.promises.readFile(filePath, 'utf-8');
+
+    return { stats, content };
   } catch (error) {
     console.error(`Error reading file: ${error}`);
     throw error;

--- a/docs/src/utils/hooks/getHookItems.ts
+++ b/docs/src/utils/hooks/getHookItems.ts
@@ -35,7 +35,7 @@ export const getHookItems = async (): Promise<HookItem[]> => {
       return {
         text: hook,
         description: jsdoc.description.description,
-        category: jsdoc.category?.name || 'Hooks',
+        category: jsdoc.category?.name,
         link: `/functions/hooks/${hook}`
       };
     })

--- a/docs/src/utils/hooks/getHookItems.ts
+++ b/docs/src/utils/hooks/getHookItems.ts
@@ -5,6 +5,7 @@ import { getHooks } from './getHooks';
 
 interface HookItem {
   text: string;
+  category: string;
   description: string;
   link: string;
 }
@@ -14,10 +15,10 @@ export const getHookItems = async (): Promise<HookItem[]> => {
 
   const sidebar = await Promise.all(
     hooks.map(async (hook) => {
-      const file = await getHookFile(hook);
+      const { content } = await getHookFile(hook);
 
       const jsdocCommentRegex = /\/\*\*\s*\n([^\\*]|(\*(?!\/)))*\*\//;
-      const match = file.match(jsdocCommentRegex);
+      const match = content.match(jsdocCommentRegex);
 
       if (!match) {
         console.error(`No jsdoc comment found for ${hook}`);
@@ -34,6 +35,7 @@ export const getHookItems = async (): Promise<HookItem[]> => {
       return {
         text: hook,
         description: jsdoc.description.description,
+        category: jsdoc.category?.name || 'Hooks',
         link: `/functions/hooks/${hook}`
       };
     })

--- a/docs/src/utils/parseHookJsdoc.ts
+++ b/docs/src/utils/parseHookJsdoc.ts
@@ -5,9 +5,10 @@ export const parseHookJsdoc = (file: string) => {
   const description = jsdoc.tags.find(({ tag }) => tag === 'description');
   const usage = jsdoc.tags.find(({ tag }) => tag === 'example');
   const deprecated = jsdoc.tags.find(({ tag }) => tag === 'deprecated');
+  const category = jsdoc.tags.find(({ tag }) => tag === 'category');
   const apiParameters = jsdoc.tags.filter(
     ({ tag }) => tag === 'param' || tag === 'overload' || tag === 'returns'
   );
 
-  return { description, usage, apiParameters, deprecated };
+  return { description, usage, apiParameters, deprecated, category };
 };

--- a/src/hooks/useBattery/useBattery.ts
+++ b/src/hooks/useBattery/useBattery.ts
@@ -27,7 +27,7 @@ interface UseBatteryStateReturn {
 /**
  * @name useBattery
  * @description - Hook for getting information about battery status
- * @category Sensors
+ * @category Browser
  *
  * @returns {UseBatteryStateReturn} Object containing battery information & Battery API support
  *

--- a/src/hooks/useBattery/useBattery.ts
+++ b/src/hooks/useBattery/useBattery.ts
@@ -27,6 +27,7 @@ interface UseBatteryStateReturn {
 /**
  * @name useBattery
  * @description - Hook for getting information about battery status
+ * @category Sensors
  *
  * @returns {UseBatteryStateReturn} Object containing battery information & Battery API support
  *

--- a/src/hooks/useBoolean/useBoolean.ts
+++ b/src/hooks/useBoolean/useBoolean.ts
@@ -11,6 +11,7 @@ type UseBooleanReturn = [
 /**
  * @name useBoolean
  * @description - Hook provides a boolean state and a function to toggle the boolean value
+ * @category Utilities
  *
  * @param {boolean} [initialValue=false] The initial boolean value
  * @returns {UseBooleanReturn} An object containing the boolean state value and utility functions to manipulate the state

--- a/src/hooks/useBrowserLanguage/useBrowserLanguage.ts
+++ b/src/hooks/useBrowserLanguage/useBrowserLanguage.ts
@@ -10,6 +10,7 @@ const subscribe = (cb: () => void) => {
 /**
  * @name useBrowserLanguage
  * @description - Hook that returns the current browser language
+ * @category Browser
  *
  * @returns {string} The current browser language
  *

--- a/src/hooks/useClickOutside/useClickOutside.ts
+++ b/src/hooks/useClickOutside/useClickOutside.ts
@@ -38,6 +38,7 @@ export type UseClickOutside = {
 /**
  * @name useClickOutside
  * @description - Hook to handle click events outside the specified target element(s)
+ * @category Sensors
  *
  * @overload
  * @template Target The target element(s)

--- a/src/hooks/useCopyToClipboard/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard/useCopyToClipboard.ts
@@ -20,6 +20,7 @@ interface UseCopyToClipboardReturn {
 /**
  * @name useCopyToClipboard
  * @description - Hook that manages a copy to clipboard
+ * @category Browser
  *
  * @returns {UseCopyToClipboardReturn} An object containing the boolean state value and utility functions to manipulate the state
  *

--- a/src/hooks/useCounter/useCounter.ts
+++ b/src/hooks/useCounter/useCounter.ts
@@ -41,6 +41,7 @@ export type UseCounter = {
 /**
  * @name useCounter
  * @description - Hook that manages a counter with increment, decrement, reset, and set functionalities
+ * @category Utilities
  *
  * @overload
  * @param {number} [initialValue=0] The initial number value
@@ -56,7 +57,7 @@ export type UseCounter = {
  *
  * @example
  * const { count, dec, inc, reset, set } = useCounter(5);
- * 
+ *
  * @example
  * const { count, dec, inc, reset, set } = useCounter({ initialValue: 5, min: 0, max: 10 });
  */

--- a/src/hooks/useDebounceCallback/useDebounceCallback.ts
+++ b/src/hooks/useDebounceCallback/useDebounceCallback.ts
@@ -5,6 +5,7 @@ import { debounce } from '@/utils/helpers';
 /**
  * @name useDebounceCallback
  * @description - Hook that creates a debounced callback and returns a stable reference of it
+ * @category Utilities
  *
  * @template Params The type of the params
  * @template Return The type of the return

--- a/src/hooks/useDebounceValue/useDebounceValue.ts
+++ b/src/hooks/useDebounceValue/useDebounceValue.ts
@@ -5,6 +5,7 @@ import { useDebounceCallback } from '../useDebounceCallback/useDebounceCallback'
 /**
  * @name useDebounceValue
  * @description - Hook that creates a debounced value and returns a stable reference of it
+ * @category Utilities
  *
  * @template Value The type of the value
  * @param {Value} value The value to be debounced

--- a/src/hooks/useDidUpdate/useDidUpdate.ts
+++ b/src/hooks/useDidUpdate/useDidUpdate.ts
@@ -6,6 +6,7 @@ import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomo
 /**
  * @name useDidUpdate
  * @description – Hook that behaves like useEffect, but skips the effect on the initial render
+ * @category Component
  *
  * @param {EffectCallback} effect The effect callback
  * @param {DependencyList} [deps] The dependencies list for the effect

--- a/src/hooks/useDidUpdate/useDidUpdate.ts
+++ b/src/hooks/useDidUpdate/useDidUpdate.ts
@@ -6,7 +6,7 @@ import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomo
 /**
  * @name useDidUpdate
  * @description – Hook that behaves like useEffect, but skips the effect on the initial render
- * @category Component
+ * @category Lifecycle
  *
  * @param {EffectCallback} effect The effect callback
  * @param {DependencyList} [deps] The dependencies list for the effect

--- a/src/hooks/useDocumentEvent/useDocumentEvent.ts
+++ b/src/hooks/useDocumentEvent/useDocumentEvent.ts
@@ -4,6 +4,7 @@ import { useEventListener } from '../useEventListener/useEventListener';
 /**
  * @name useDocumentEvent
  * @description - Hook attaches an event listener to the document object for the specified event
+ * @category Browser
  *
  * @template Event Key of document event map.
  * @param {Event} event The event to listen for.

--- a/src/hooks/useDocumentTitle/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle/useDocumentTitle.ts
@@ -21,6 +21,7 @@ export type UseDocumentTitleReturn = [
 /**
  * @name useDocumentTitle
  * @description - Hook that manages the document title and allows updating it
+ * @category Browser
  *
  * @param {string} [value] The initial title. If not provided, the current document title will be used
  * @param {boolean} [options.restoreOnUnmount] Restore the previous title on unmount

--- a/src/hooks/useDocumentVisibility/useDocumentVisibility.ts
+++ b/src/hooks/useDocumentVisibility/useDocumentVisibility.ts
@@ -12,6 +12,7 @@ const subscribe = (callback: () => void) => {
 /**
  * @name useDocumentVisibility
  * @description – Hook that provides the current visibility state of the document
+ * @category Browser
  *
  * @returns {DocumentVisibilityState} The current visibility state of the document, which can be 'visible' or 'hidden'
  *

--- a/src/hooks/useEvent/useEvent.ts
+++ b/src/hooks/useEvent/useEvent.ts
@@ -5,6 +5,7 @@ import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect/useIsomo
 /**
  * @name useEvent
  * @description - Hook that creates an event and returns a stable reference of it
+ * @category Browser
  *
  * @template Params The type of the params
  * @template Return The type of the return

--- a/src/hooks/useEyeDropper/useEyeDropper.ts
+++ b/src/hooks/useEyeDropper/useEyeDropper.ts
@@ -23,6 +23,7 @@ export interface UseEyeDropperReturn {
 /**
  * @name useEyeDropper
  * @description - Hook that gives you access to the eye dropper
+ * @category Browser
  *
  * @param {string} [initialValue=undefined] The initial value for the eye dropper
  * @returns {UseEyeDropperReturn} An object containing the supported status, the value and the open method

--- a/src/hooks/useFavicon/useFavicon.ts
+++ b/src/hooks/useFavicon/useFavicon.ts
@@ -10,6 +10,7 @@ export type UseFaviconReturn = [string, Dispatch<SetStateAction<string>>];
 /**
  * @name useFavicon
  * @description - Hook that manages the favicon
+ * @category Browser
  *
  * @param {string} [initialFavicon] The initial favicon. If not provided, the current favicon will be used
  * @returns {UseFaviconReturn} An array containing the current favicon and a function to update the favicon

--- a/src/hooks/useFps/useFps.ts
+++ b/src/hooks/useFps/useFps.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 /**
  * @name useFps
  * @description - Hook that measures frames per second
+ * @category Sensors
  *
  * @returns {number} A number which determines frames per second
  *

--- a/src/hooks/useFullscreen/useFullscreen.ts
+++ b/src/hooks/useFullscreen/useFullscreen.ts
@@ -53,6 +53,7 @@ export type UseFullScreen = {
 /**
  * @name useFullscreen
  * @description - Hook to handle fullscreen events
+ * @category Browser
  *
  * @overload
  * @template Target The target element for fullscreen

--- a/src/hooks/useHash/useHash.ts
+++ b/src/hooks/useHash/useHash.ts
@@ -8,6 +8,7 @@ type UseHashReturn = [string, (value: string) => void];
 /**
  * @name useHash
  * @description - Hook that manages the hash value
+ * @category Browser
  *
  * @returns {UseHashReturn} An array containing the hash value and a function to set the hash value
  *

--- a/src/hooks/useHotkeys/useHotkeys.ts
+++ b/src/hooks/useHotkeys/useHotkeys.ts
@@ -39,6 +39,7 @@ export type UseHotkeysKey = { key: string; code: string; alias: string };
 /**
  * @name useHotkeys
  * @description - Hook that listens for hotkeys
+ * @category Sensors
  *
  * @param {UseHotkeysHotkeys} hotkeys The key or keys to listen for
  * @param {(event: KeyboardEvent) => void} callback The callback function to be called when the hotkey is pressed

--- a/src/hooks/useHover/useHover.ts
+++ b/src/hooks/useHover/useHover.ts
@@ -32,6 +32,7 @@ export type UseHover = {
 /**
  * @name useHover
  * @description - Hook that defines the logic when hovering an element
+ * @category Sensors
  *
  * @overload
  * @template Target The target element

--- a/src/hooks/useIdle/useIdle.ts
+++ b/src/hooks/useIdle/useIdle.ts
@@ -28,6 +28,7 @@ export interface UseIdleReturn {
 /**
  * @name useIdle
  * @description - Hook that defines the logic when the user is idle
+ * @category Sensors
  *
  * @param {number} [milliseconds=ONE_MINUTE] The idle time in milliseconds
  * @param {boolean} [options.initialState=false] The options for the hook

--- a/src/hooks/useInterval/useInterval.ts
+++ b/src/hooks/useInterval/useInterval.ts
@@ -26,6 +26,7 @@ type UseInterval = {
 /**
  * @name useInterval
  * @description - Hook that makes and interval and returns controlling functions
+ * @category Time
  *
  * @overload
  * @param {() => void} callback Any callback function

--- a/src/hooks/useIsFirstRender/useIsFirstRender.ts
+++ b/src/hooks/useIsFirstRender/useIsFirstRender.ts
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 /**
  * @name useIsFirstRender
  * @description - Hook that returns true if the component is first render
+ * @category Component
  *
  * @returns {boolean} True if the component is first render
  *

--- a/src/hooks/useIsFirstRender/useIsFirstRender.ts
+++ b/src/hooks/useIsFirstRender/useIsFirstRender.ts
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 /**
  * @name useIsFirstRender
  * @description - Hook that returns true if the component is first render
- * @category Component
+ * @category Lifecycle
  *
  * @returns {boolean} True if the component is first render
  *

--- a/src/hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.ts
@@ -5,6 +5,7 @@ import { isClient } from '@/utils/helpers';
 /**
  * @name useIsomorphicLayoutEffect
  * @description - Hook conditionally selects either `useLayoutEffect` or `useEffect` based on the environment
+ * @category Component
  *
  * @example
  * useIsomorphicLayoutEffect(() => console.log('effect'), [])

--- a/src/hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.ts
@@ -5,7 +5,7 @@ import { isClient } from '@/utils/helpers';
 /**
  * @name useIsomorphicLayoutEffect
  * @description - Hook conditionally selects either `useLayoutEffect` or `useEffect` based on the environment
- * @category Component
+ * @category Lifecycle
  *
  * @example
  * useIsomorphicLayoutEffect(() => console.log('effect'), [])

--- a/src/hooks/useKeyPress/useKeyPress.ts
+++ b/src/hooks/useKeyPress/useKeyPress.ts
@@ -15,6 +15,7 @@ export type UseKeyPressOptions = {
 /**
  * @name useKeyPress
  * @description - Hook that listens for key press events
+ * @category Sensors
  *
  * @param {UseKeyPressKey} key The key or keys to listen for
  * @param {UseEventListenerTarget} [options.target=window] The target to attach the event listeners to

--- a/src/hooks/useKeyboard/useKeyboard.ts
+++ b/src/hooks/useKeyboard/useKeyboard.ts
@@ -14,6 +14,7 @@ export type UseKeyboardParams = {
 /**
  * @name useKeyboard
  * @description - Hook that help to listen for keyboard events
+ * @category Sensors
  *
  * @param {UseEventListenerTarget} [target=window] The target to attach the event listeners to
  * @param {(event: KeyboardEvent) => void} [onKeyDown] The callback function to be invoked on key down

--- a/src/hooks/useKeysPressed/useKeysPressed.ts
+++ b/src/hooks/useKeysPressed/useKeysPressed.ts
@@ -16,6 +16,7 @@ interface UseKeysPressedParams {
 /**
  * @name useKeysPressed
  * @description - Hook for get keys that were pressed
+ * @category Sensors
  *
  * @param {UseEventListenerTarget} [params.target=window] The target to attach the event listeners to
  * @param {boolean} [params.enabled=bollean] Enable or disable the event listeners

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -4,7 +4,7 @@ import { useStorage } from '../useStorage/useStorage';
 /**
  * @name useLocalStorage
  * @description - Hook that manages local storage value
- * @category State
+ * @category Browser
  *
  * @template Value The type of the value
  * @param {string} key The key of the storage

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -4,6 +4,7 @@ import { useStorage } from '../useStorage/useStorage';
 /**
  * @name useLocalStorage
  * @description - Hook that manages local storage value
+ * @category State
  *
  * @template Value The type of the value
  * @param {string} key The key of the storage

--- a/src/hooks/useLongPress/useLongPress.ts
+++ b/src/hooks/useLongPress/useLongPress.ts
@@ -40,6 +40,7 @@ const DEFAULT_THRESHOLD_TIME = 400;
 /**
  * @name useLongPress
  * @description - Hook that defines the logic when long pressing an element
+ * @category Sensors
  *
  * @overload
  * @template Target The target element

--- a/src/hooks/useMediaQuery/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery/useMediaQuery.ts
@@ -5,6 +5,7 @@ const getServerSnapshot = () => false;
 /**
  * @name useMediaQuery
  * @description - Hook that manages a media query
+ * @category Browser
  *
  * @param {string} query The media query string
  * @returns {boolean} A boolean indicating if the media query matches

--- a/src/hooks/useMemory/useMemory.ts
+++ b/src/hooks/useMemory/useMemory.ts
@@ -22,6 +22,7 @@ export interface UseMemoryReturn {
 /**
  * @name useMemory
  * @description - Hook that gives you current memory usage
+ * @category Browser
  *
  * @returns {UseMemoryReturn} An object containing the current memory usage
  *

--- a/src/hooks/useMount/useMount.ts
+++ b/src/hooks/useMount/useMount.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 /**
  * @name useMount
  * @description - Hook that executes a callback when the component mounts
+ * @category Component
  *
  * @param {EffectCallback} effect The callback to execute
  *

--- a/src/hooks/useMount/useMount.ts
+++ b/src/hooks/useMount/useMount.ts
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 /**
  * @name useMount
  * @description - Hook that executes a callback when the component mounts
- * @category Component
+ * @category Lifecycle
  *
  * @param {EffectCallback} effect The callback to execute
  *

--- a/src/hooks/useMouse/useMouse.ts
+++ b/src/hooks/useMouse/useMouse.ts
@@ -44,6 +44,7 @@ export type UseMouse = {
 /**
  * @name useMouse
  * @description - Hook that manages a mouse position
+ * @category Sensors
  *
  * @overload
  * @template Target The target element

--- a/src/hooks/useNetwork/useNetwork.ts
+++ b/src/hooks/useNetwork/useNetwork.ts
@@ -40,6 +40,7 @@ export const getConnection = () =>
 /**
  * @name useNetwork
  * @description - Hook to track network status
+ * @category Sensors
  *
  * @returns {UseNetworkReturn} An object containing the network status
  *

--- a/src/hooks/useOnline/useOnline.ts
+++ b/src/hooks/useOnline/useOnline.ts
@@ -14,6 +14,7 @@ const subscribe = (callback: () => void) => {
 /**
  * @name useOnline
  * @description - Hook that manages if the user is online
+ * @category Sensors
  *
  * @returns {boolean} A boolean indicating if the user is online
  *

--- a/src/hooks/useOperatingSystem/useOperatingSystem.ts
+++ b/src/hooks/useOperatingSystem/useOperatingSystem.ts
@@ -20,6 +20,7 @@ export const getOperatingSystem = (): OperatingSystem => {
 /**
  * @name useOperatingSystem
  * @description - Hook that returns the operating system of the current browser
+ * @category Browser
  *
  * @returns {OperatingSystem} The operating system
  *

--- a/src/hooks/useOrientation/useOrientation.ts
+++ b/src/hooks/useOrientation/useOrientation.ts
@@ -13,6 +13,7 @@ export interface UseOrientationReturn {
 /**
  * @name useOrientation
  * @description - Hook that returns the current screen orientation
+ * @category Browser
  *
  * @returns {UseOrientationReturn} An object containing the current screen orientation
  *

--- a/src/hooks/usePageLeave/usePageLeave.ts
+++ b/src/hooks/usePageLeave/usePageLeave.ts
@@ -5,6 +5,7 @@ import { useEvent } from '../useEvent/useEvent';
 /**
  * @name usePageLeave
  * @description - Hook what calls given function when mouse leaves the page
+ * @category Sensors
  *
  * @param {() => void} [callback] The callback function what calls then mouse leaves the page
  * @returns {boolean} A boolean which determines if the mouse left the page

--- a/src/hooks/usePermission/usePermission.ts
+++ b/src/hooks/usePermission/usePermission.ts
@@ -31,6 +31,7 @@ export interface UsePermissionReturn {
 /**
  *  @name usePermission
  *  @description - Hook that gives you the state of permission
+ *  @category Browser
  *
  *  @returns {UsePermissionReturn} An object containing the state and the supported status
  *

--- a/src/hooks/usePreferredColorScheme/usePreferredColorScheme.ts
+++ b/src/hooks/usePreferredColorScheme/usePreferredColorScheme.ts
@@ -6,6 +6,7 @@ export type UsePreferredColorSchemeReturn = 'dark' | 'light' | 'no-preference';
 /**
  * @name usePreferredColorScheme
  * @description - Hook that returns user preferred color scheme
+ * @category Browser
  *
  * @returns {UsePreferredColorSchemeReturn} String of preferred color scheme
  *

--- a/src/hooks/usePreferredLanguages/usePreferredLanguages.ts
+++ b/src/hooks/usePreferredLanguages/usePreferredLanguages.ts
@@ -12,6 +12,7 @@ const subscribe = (callback: () => void) => {
 /**
  * @name usePreferredLanguages
  * @description Hook that returns a browser preferred languages from navigator
+ * @category Browser
  *
  * @returns {readonly string[]} An array of strings representing the user's preferred languages
  *

--- a/src/hooks/usePrevious/usePrevious.ts
+++ b/src/hooks/usePrevious/usePrevious.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 /**
  * @name usePrevious
  * @description - Hook that returns the previous value
+ * @category Utilities
  *
  * @template Value The type of the value
  * @param {Value} value The value to get the previous value

--- a/src/hooks/useRenderCount/useRenderCount.ts
+++ b/src/hooks/useRenderCount/useRenderCount.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 /**
  * @name useRenderCount
  * @description - Hook returns count component render times
- * @category Component
+ * @category Lifecycle
  *
  * @returns {number} A number which determines how many times component renders
  *

--- a/src/hooks/useRenderCount/useRenderCount.ts
+++ b/src/hooks/useRenderCount/useRenderCount.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 /**
  * @name useRenderCount
  * @description - Hook returns count component render times
+ * @category Component
  *
  * @returns {number} A number which determines how many times component renders
  *

--- a/src/hooks/useRenderInfo/useRenderInfo.ts
+++ b/src/hooks/useRenderInfo/useRenderInfo.ts
@@ -10,6 +10,7 @@ export interface UseRenderInfoReturn {
 /**
  * @name useRenderInfo
  * @description - Hook for getting information about component rerender
+ * @category Component
  *
  * @param {string} [name='Unknown'] Component name
  * @param {boolean} [log=true] Toggle logging

--- a/src/hooks/useRenderInfo/useRenderInfo.ts
+++ b/src/hooks/useRenderInfo/useRenderInfo.ts
@@ -10,7 +10,7 @@ export interface UseRenderInfoReturn {
 /**
  * @name useRenderInfo
  * @description - Hook for getting information about component rerender
- * @category Component
+ * @category Lifecycle
  *
  * @param {string} [name='Unknown'] Component name
  * @param {boolean} [log=true] Toggle logging

--- a/src/hooks/useRerender/useRerender.ts
+++ b/src/hooks/useRerender/useRerender.ts
@@ -11,6 +11,7 @@ interface UseRerenderReturns {
 /**
  * @name useRerender
  * @description - Hook that defines the logic to force rerender a component
+ * @category Component
  *
  * @returns {UseRerenderReturns} An object containing the id and update function
  *

--- a/src/hooks/useRerender/useRerender.ts
+++ b/src/hooks/useRerender/useRerender.ts
@@ -11,7 +11,7 @@ interface UseRerenderReturns {
 /**
  * @name useRerender
  * @description - Hook that defines the logic to force rerender a component
- * @category Component
+ * @category Lifecycle
  *
  * @returns {UseRerenderReturns} An object containing the id and update function
  *

--- a/src/hooks/useScript/useScript.ts
+++ b/src/hooks/useScript/useScript.ts
@@ -14,6 +14,7 @@ export interface UseScriptOptions extends ComponentProps<'script'> {
 /**
  * @name useScript
  * @description - Hook that manages a script with onLoad, onError, and removeOnUnmount functionalities
+ * @category Browser
  *
  * @param {string} src The source of the script
  * @param {UseScriptOptions} [options] The options of the script extends from attributes script tag

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -4,6 +4,7 @@ import { useStorage } from '../useStorage/useStorage';
 /**
  * @name useSessionStorage
  * @description - Hook that manages session storage value
+ * @category State
  *
  * @template Value The type of the value
  * @param {string} key The key of the storage

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -4,7 +4,7 @@ import { useStorage } from '../useStorage/useStorage';
 /**
  * @name useSessionStorage
  * @description - Hook that manages session storage value
- * @category State
+ * @category Browser
  *
  * @template Value The type of the value
  * @param {string} key The key of the storage

--- a/src/hooks/useShare/useShare.ts
+++ b/src/hooks/useShare/useShare.ts
@@ -23,6 +23,7 @@ export interface UseShareReturn {
 /**
  * @name useShare
  * @description - Hook that utilizes the share api
+ * @category Browser
  *
  * @param {UseShareParams} [params] The use share options
  * @returns {UseShareReturn}

--- a/src/hooks/useTextSelection/useTextSelection.ts
+++ b/src/hooks/useTextSelection/useTextSelection.ts
@@ -24,6 +24,7 @@ export interface UseTextSelectionReturn {
 /**
  * @name useTextSelection
  * @description - Hook that manages the text selection
+ * @category Sensors
  *
  * @returns {UseTextSelectionReturn} An object containing the current text selection
  *

--- a/src/hooks/useTime/useTime.ts
+++ b/src/hooks/useTime/useTime.ts
@@ -18,6 +18,7 @@ export interface UseTimeReturn {
 /**
  * @name useTime
  * @description - Hook that gives you current time in different values
+ * @category Time
  *
  * @returns {UseTimeReturn} An object containing the current time
  *

--- a/src/hooks/useTimeout/useTimeout.ts
+++ b/src/hooks/useTimeout/useTimeout.ts
@@ -13,6 +13,7 @@ interface UseTimeoutReturn {
 /**
  * @name useTimeout
  * @description - Hook that executes a callback function after a specified delay
+ * @category Time
  *
  * @param {() => void} callback The function to be executed after the timeout
  * @param {number} delay The delay in milliseconds before the timeout executes the callback function

--- a/src/hooks/useUnmount/useUnmount.ts
+++ b/src/hooks/useUnmount/useUnmount.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 /**
  * @name useUnmount
  * @description - Hook that defines the logic when unmounting a component
+ * @category Component
  *
  * @param {() => void} callback The callback function to be invoked on component unmount
  * @returns {void}

--- a/src/hooks/useUnmount/useUnmount.ts
+++ b/src/hooks/useUnmount/useUnmount.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 /**
  * @name useUnmount
  * @description - Hook that defines the logic when unmounting a component
- * @category Component
+ * @category Lifecycle
  *
  * @param {() => void} callback The callback function to be invoked on component unmount
  * @returns {void}

--- a/src/hooks/useWebSocket/useWebSocket.ts
+++ b/src/hooks/useWebSocket/useWebSocket.ts
@@ -28,6 +28,7 @@ export interface UseWebSocketReturn {
 /**
  * @name useWebSocket
  * @description - Hook that connects to a WebSocket server and handles incoming and outgoing messages
+ * @category Network
  *
  * @param {UseWebSocketUrl} url The URL of the WebSocket server
  * @param {(webSocket: WebSocket) => void} [options.onConnected] The callback function that is called when the WebSocket connection is established

--- a/src/hooks/useWindowEvent/useWindowEvent.ts
+++ b/src/hooks/useWindowEvent/useWindowEvent.ts
@@ -4,6 +4,7 @@ import { useEventListener } from '../useEventListener/useEventListener';
 /**
  * @name useWindowEvent
  * @description - Hook attaches an event listener to the window object for the specified event
+ * @category Browser
  *
  * @template Event Key of window event map.
  * @param {Event} event The event to listen for.

--- a/src/hooks/useWindowSize/useWindowSize.ts
+++ b/src/hooks/useWindowSize/useWindowSize.ts
@@ -21,6 +21,7 @@ export interface UseWindowSizeReturn {
 /**
  * @name useWindowSize
  * @description - Hook that manages a window size
+ * @category Browser
  *
  * @param {number} [params.initialWidth=Number.POSITIVE_INFINITY] The initial window width
  * @param {number} [params.initialHeight=Number.POSITIVE_INFINITY] The initial window height


### PR DESCRIPTION
Что нового:
* Кластеризация по категориям
* Мета информация о хуке

## Как добавить кластеризацию? 
Просто указать `@category` в описание хука 
```diff
/**
 * @name useBattery
 * @description - Hook for getting information about battery status
+* @category Sensors 
 *
 * @returns {UseBatteryStateReturn} Object containing battery information & Battery API support
 *
 * @example
 * const { supported, loading, charging, chargingTime, dischargingTime, level } = useBattery();
 */
 ```
Автоматически перестроится боковое меню, а также мета информация 

## Что за мета информация? 
В каждом хуке в шапке добавился блок (позже можно будет расширять его)
![Снимок экрана 2024-06-27 в 15 32 06](https://github.com/siberiacancode/reactuse/assets/149865959/1987c1c8-900d-49fe-9dd8-b4b906177f12)
