### PR TITLE
[bug]: useHover

### DIFF
--- a/src/hooks/useHotkeys/useHotkeys.test.ts
+++ b/src/hooks/useHotkeys/useHotkeys.test.ts
@@ -1,0 +1,33 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useHotkeys } from './useHotkeys';
+
+it('Should use hotkeys', () => {
+  const callback = vi.fn();
+
+  renderHook(() => useHotkeys('a', callback, { target: document }));
+
+  expect(callback).not.toBeCalled();
+});
+
+it('The callback should be called when the hotkey is pressed', () => {
+  const callback = vi.fn();
+
+  renderHook(() => useHotkeys('a', callback, { target: document }));
+
+  expect(callback).not.toBeCalled();
+
+  act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' })));
+
+  expect(callback).toBeCalledTimes(1);
+});
+
+it("Shouldn't call callback when clicking outside of target", () => {
+  const callback = vi.fn();
+
+  renderHook(() => useHotkeys('a', callback, { target: document }));
+
+  act(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' })));
+
+  expect(callback).not.toBeCalled();
+});

--- a/src/hooks/useHotkeys/useHotkeys.test.ts
+++ b/src/hooks/useHotkeys/useHotkeys.test.ts
@@ -22,7 +22,7 @@ it('The callback should be called when the hotkey is pressed', () => {
   expect(callback).toBeCalledTimes(1);
 });
 
-it("Shouldn't call callback when clicking outside of target", () => {
+it("Shouldn't call callback when pressing outside of target", () => {
   const callback = vi.fn();
 
   renderHook(() => useHotkeys('a', callback, { target: document }));

--- a/src/hooks/useHover/useHover.ts
+++ b/src/hooks/useHover/useHover.ts
@@ -77,8 +77,12 @@ export type UseHover = {
  * });
  */
 export const useHover = ((...params: any[]) => {
+  console.log('@', params[0] instanceof Function);
+
   const target = (
-    params[0] instanceof Function || !('current' in params[0]) ? undefined : params[0]
+    params[0] instanceof Function || !('current' in params[0] || params[0] instanceof Element)
+      ? undefined
+      : params[0]
   ) as UseHoverTarget | undefined;
 
   const options = (
@@ -103,6 +107,8 @@ export const useHover = ((...params: any[]) => {
     options?.onLeave?.();
     setHovering(false);
   };
+
+  console.log('@@', target);
 
   useEventListener(target ?? internalRef, 'mouseenter', onMouseEnter);
   useEventListener(target ?? internalRef, 'mouseleave', onMouseLeave);

--- a/src/hooks/useHover/useHover.ts
+++ b/src/hooks/useHover/useHover.ts
@@ -77,8 +77,6 @@ export type UseHover = {
  * });
  */
 export const useHover = ((...params: any[]) => {
-  console.log('@', params[0] instanceof Function);
-
   const target = (
     params[0] instanceof Function || !('current' in params[0] || params[0] instanceof Element)
       ? undefined
@@ -107,8 +105,6 @@ export const useHover = ((...params: any[]) => {
     options?.onLeave?.();
     setHovering(false);
   };
-
-  console.log('@@', target);
 
   useEventListener(target ?? internalRef, 'mouseenter', onMouseEnter);
   useEventListener(target ?? internalRef, 'mouseleave', onMouseLeave);


### PR DESCRIPTION
Починил баг с типизацией useHover, теперь можно в качестве target прокидывать Element и тебе не будет возвращаться кортэж с рефом и флагом