### PR TITLE
[fix] 💎 'useClipboard' adapted for mobile devices

### DIFF
--- a/src/hooks/useClipboard/useClipboard.ts
+++ b/src/hooks/useClipboard/useClipboard.ts
@@ -8,6 +8,8 @@ export const isPermissionAllowed = (status: PermissionState) =>
 export const legacyCopyToClipboard = (value: string) => {
   const tempTextArea = document.createElement('textarea');
   tempTextArea.value = value;
+  tempTextArea.readOnly = true;
+  tempTextArea.style.fontSize = '16px';
   document.body.appendChild(tempTextArea);
   tempTextArea.select();
   document.execCommand('copy');


### PR DESCRIPTION
'useClipboard' adapted for mobile devices: `readonly` for prevent of keyboard appear, `fontSize` for prevent zoom on IOS