### PR TITLE
[docs]: fix incorrect description for the useList hook

### DIFF
--- a/src/hooks/useList/useList.ts
+++ b/src/hooks/useList/useList.ts
@@ -20,7 +20,7 @@ export interface UseListReturn<Item> {
 
 /**
  * @name useList
- * @description - Hook that defines the logic when unmounting a component
+ * @description - Hook that provides state and helper methods to manage a list of items
  * @category Utilities
  *
  * @template Item The type of the item


### PR DESCRIPTION
The JSDoc description referred to unmounting logic instead of the actual list management functionality.
This commit updates the description to accurately reflect the hook’s purpose.

Issue: https://github.com/siberiacancode/reactuse/issues/271