### PR TITLE
Fix useElementSize hook

### DIFF
--- a/src/hooks/useElementSize/useElementSize.test.ts
+++ b/src/hooks/useElementSize/useElementSize.test.ts
@@ -32,6 +32,7 @@ const mockResizeObserver = class ResizeObserver {
 
 beforeEach(() => void vi.stubGlobal('ResizeObserver', mockResizeObserver));
 afterEach(() => void vi.unstubAllGlobals());
+afterEach(() => void vi.restoreAllMocks());
 
 const targets = [
   undefined,
@@ -65,7 +66,11 @@ targets.forEach((target) => {
         return useElementSize<HTMLDivElement>({ width: 200, height: 200 });
       });
 
-      expect(result.current.value).toStrictEqual({ width: 200, height: 200 });
+      if (!target) {
+        expect(result.current.value).toStrictEqual({ width: 200, height: 200 });
+      } else {
+        expect(result.current.value).toStrictEqual({ width: 0, height: 0 });
+      }
     });
 
     it('Should change value after resize', () => {
@@ -85,6 +90,10 @@ targets.forEach((target) => {
       act(() => {
         const element = (target ? getElement(target) : result.current.ref.current) as Element;
         if (!element) return;
+
+        vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+          () => new DOMRect(0, 0, 200, 200)
+        );
 
         trigger.callback(element, [
           { contentRect: { width: 200, height: 200 } }

--- a/src/hooks/useRefState/useRefState.ts
+++ b/src/hooks/useRefState/useRefState.ts
@@ -10,8 +10,10 @@ export interface StateRef<Value> {
 const createRefState = <Value>(initialValue: Value | undefined, rerender: () => void) => {
   let temp = initialValue;
   function ref(value: Value) {
-    temp = value;
-    rerender();
+    if (temp !== value) {
+      temp = value;
+      rerender();
+    }
   }
 
   Object.defineProperty(ref, 'current', {
@@ -19,8 +21,10 @@ const createRefState = <Value>(initialValue: Value | undefined, rerender: () => 
       return temp;
     },
     set(value: Value) {
-      rerender();
-      temp = value;
+      if (temp !== value) {
+        temp = value;
+        rerender();
+      }
     },
     configurable: true,
     enumerable: true


### PR DESCRIPTION
- useRefState: предотвращение ререндера при попытке установить значение, которое не отличается от текущего
- получение корректного размера элемента через getBoundingClientRect(), т.к. contentRect не учитывает внутренние padding отступы
- установка значения размера элемента до отрисовки браузера с помощью useLayoutEffect, тем самым избегаем случая, когда на мгновение на экране может появиться дефолтное значение 0