### PR TITLE
feat/use-wake-lock 🧊 feat: implement useWakeLock hook

### DIFF
--- a/packages/core/src/bundle/hooks/index.js
+++ b/packages/core/src/bundle/hooks/index.js
@@ -121,6 +121,7 @@ export * from './useTimer/useTimer';
 export * from './useToggle/useToggle';
 export * from './useUnmount/useUnmount';
 export * from './useVibrate/useVibrate';
+export * from './useWakeLock/useWakeLock';
 export * from './useWebSocket/useWebSocket';
 export * from './useWindowEvent/useWindowEvent';
 export * from './useWindowFocus/useWindowFocus';

--- a/packages/core/src/bundle/hooks/useWakeLock/useWakeLock.js
+++ b/packages/core/src/bundle/hooks/useWakeLock/useWakeLock.js
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+/**
+ * @name useWakeLock
+ * @description - Hook that provides an interface to the Screen Wake Lock API, allowing prevention of device screen dimming or locking
+ * @category Browser
+ *
+ * @browserapi navigator.wakeLock https://developer.mozilla.org/en-US/docs/Web/API/WakeLock
+ *
+ * @param {UseWakeLockOptions} [options] Configuration options for the hook.
+ * @returns {UseWakeLockReturn} An object containing the wake lock state and control methods.
+ *
+ * @example
+ * const { supported, active, request, release } = useWakeLock();
+ */
+export const useWakeLock = (options) => {
+  const supported = typeof navigator !== 'undefined' && 'wakeLock' in navigator;
+  const [active, setActive] = useState(false);
+  const wakeLockSentinel = useRef(null);
+  const { type, autoReacquire = false, onError, onRelease, onRequest } = options ?? {};
+  const handleRelease = useCallback(() => {
+    setActive(false);
+    wakeLockSentinel.current = null;
+    onRelease?.();
+  }, []);
+  const request = useCallback(async () => {
+    if (!supported) {
+      onError?.(new Error('Wake Lock API is not supported in this browser.'));
+      return;
+    }
+    try {
+      wakeLockSentinel.current = await navigator.wakeLock.request(type);
+      wakeLockSentinel.current.addEventListener('release', handleRelease);
+      setActive(true);
+      onRequest?.();
+    } catch (error) {
+      onError?.(error);
+    }
+  }, [supported, type, handleRelease]);
+  const release = useCallback(async () => {
+    if (!wakeLockSentinel.current) return;
+    try {
+      await wakeLockSentinel.current.release();
+    } catch (error) {
+      onError?.(error);
+    }
+  }, [handleRelease]);
+  useEffect(() => {
+    if (!supported || !autoReacquire) return;
+    const listener = () => {
+      if (document.visibilityState !== 'visible' || wakeLockSentinel.current) return;
+      request();
+    };
+    document.addEventListener('visibilitychange', listener);
+    return () => document.removeEventListener('visibilitychange', listener);
+  }, [supported, autoReacquire]);
+  useEffect(
+    () => () => {
+      release();
+    },
+    []
+  );
+  return { supported, active, request, release };
+};

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -121,6 +121,7 @@ export * from './useTimer/useTimer';
 export * from './useToggle/useToggle';
 export * from './useUnmount/useUnmount';
 export * from './useVibrate/useVibrate';
+export * from './useWakeLock/useWakeLock';
 export * from './useWebSocket/useWebSocket';
 export * from './useWindowEvent/useWindowEvent';
 export * from './useWindowFocus/useWindowFocus';

--- a/packages/core/src/hooks/useWakeLock/useWakeLock.demo.tsx
+++ b/packages/core/src/hooks/useWakeLock/useWakeLock.demo.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useWakeLock } from './useWakeLock';
+
+const Demo = () => {
+  const [autoReacquire, setAutoReacquire] = useState<boolean>(false);
+
+  const { active, supported, request, release } = useWakeLock({
+    autoReacquire,
+    onRequest: () => console.log('Wake lock acquired'),
+    onRelease: () => console.log('Wake lock released'),
+    onError: (error) => console.error('Wake lock error:', error)
+  });
+
+  return (
+    <>
+      <p>
+        Screen Wake Lock API: <code>{supported ? 'supported' : 'not supported'}</code>
+      </p>
+      <p>
+        Active: <code>{active ? 'yes' : 'no'}</code>
+      </p>
+      <p className='flex gap-2'>
+        Auto reacquire:{' '}
+        <label className='flex gap-1'>
+          <input
+            checked={autoReacquire}
+            name='autoReacquire'
+            type='radio'
+            value='true'
+            onChange={() => setAutoReacquire(true)}
+          />
+          Yes
+        </label>
+        <label className='flex gap-1'>
+          <input
+            checked={!autoReacquire}
+            name='autoReacquire'
+            type='radio'
+            value='false'
+            onChange={() => setAutoReacquire(false)}
+          />
+          No
+        </label>
+      </p>
+      <div>
+        <button onClick={request} disabled={!supported || active}>
+          Acquire Wake Lock
+        </button>
+        <button onClick={release} disabled={!active}>
+          Release Wake Lock
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default Demo;

--- a/packages/core/src/hooks/useWakeLock/useWakeLock.ts
+++ b/packages/core/src/hooks/useWakeLock/useWakeLock.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Options for configuring the behavior of the `useWakeLock` hook. */
+export interface UseWakeLockOptions {
+  /** Determines if the wake lock should be automatically reacquired when the document becomes visible. */
+  autoReacquire?: boolean;
+  /** A string specifying the screen wake lock type. */
+  type?: WakeLockType;
+  /** Callback invoked when an error occurs while acquiring the wake lock. */
+  onError?: (error: Error) => void;
+  /** Callback invoked when the wake lock is released. */
+  onRelease?: () => void;
+  /** Callback invoked when the wake lock is successfully acquired. */
+  onRequest?: () => void;
+}
+
+/** The return type of the `useWakeLock` hook, providing state and control methods. */
+export interface UseWakeLockReturn {
+  /** Indicates if the wake lock is currently active. */
+  active: boolean;
+  /** Indicates if the Wake Lock API is supported in the current environment. */
+  supported: boolean;
+  /** Function to release the wake lock. */
+  release: () => Promise<void>;
+  /** Function to request the wake lock. */
+  request: () => Promise<void>;
+}
+
+/**
+ * @name useWakeLock
+ * @description - Hook that provides an interface to the Screen Wake Lock API, allowing prevention of device screen dimming or locking
+ * @category Browser
+ *
+ * @browserapi navigator.wakeLock https://developer.mozilla.org/en-US/docs/Web/API/WakeLock
+ *
+ * @param {UseWakeLockOptions} [options] Configuration options for the hook.
+ * @returns {UseWakeLockReturn} An object containing the wake lock state and control methods.
+ *
+ * @example
+ * const { supported, active, request, release } = useWakeLock();
+ */
+export const useWakeLock = (options?: UseWakeLockOptions): UseWakeLockReturn => {
+  const supported = typeof navigator !== 'undefined' && 'wakeLock' in navigator;
+
+  const [active, setActive] = useState<boolean>(false);
+  const wakeLockSentinel = useRef<WakeLockSentinel | null>(null);
+
+  const { type, autoReacquire = false, onError, onRelease, onRequest } = options ?? {};
+
+  const handleRelease = useCallback(() => {
+    setActive(false);
+    wakeLockSentinel.current = null;
+    onRelease?.();
+  }, []);
+
+  const request = useCallback(async () => {
+    if (!supported) {
+      onError?.(new Error('Wake Lock API is not supported in this browser.'));
+      return;
+    }
+
+    try {
+      wakeLockSentinel.current = await navigator.wakeLock.request(type);
+      wakeLockSentinel.current.addEventListener('release', handleRelease);
+      setActive(true);
+      onRequest?.();
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  }, [supported, type, handleRelease]);
+
+  const release = useCallback(async () => {
+    if (!wakeLockSentinel.current) return;
+
+    try {
+      await wakeLockSentinel.current.release();
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  }, [handleRelease]);
+
+  useEffect(() => {
+    if (!supported || !autoReacquire) return;
+
+    const listener = () => {
+      if (document.visibilityState !== 'visible' || wakeLockSentinel.current) return;
+      request();
+    };
+
+    document.addEventListener('visibilitychange', listener);
+    return () => document.removeEventListener('visibilitychange', listener);
+  }, [supported, autoReacquire]);
+
+  useEffect(
+    () => () => {
+      release();
+    },
+    []
+  );
+
+  return { supported, active, request, release };
+};


### PR DESCRIPTION
The hook determines if the Screen Wake Lock API is available in the user's browser and manages state accordingly

**Issue**:
https://github.com/siberiacancode/reactuse/issues/319

**Summary**:
- Implemented `request` and `release` functions to acquire and release the screen wake lock as needed
- Implemented `supported` and `active state variables to indicate API availability and the current status of the wake lock
- Add `autoReacquire` option allows the wake lock to be automatically reacquired when the document becomes visible after being hidden

**Testing evidence**:
<img width="721" alt="Снимок экрана 2025-03-30 в 18 03 48" src="https://github.com/user-attachments/assets/0cdb9e1d-9f1f-4d8e-a2c9-791d55c86d16" />

https://github.com/user-attachments/assets/3ba9c97e-4244-4ac4-864c-500cd746560f

