### PR TITLE
Fix/use state history incorrect undo behavior

### DIFF
--- a/packages/core/src/bundle/hooks/useStateHistory/useStateHistory.js
+++ b/packages/core/src/bundle/hooks/useStateHistory/useStateHistory.js
@@ -1,59 +1,138 @@
-import { useRef, useState } from 'react';
+import { useCallback, useMemo, useReducer } from 'react';
+// Reducer функция
+function stateHistoryReducer(state, action) {
+  switch (action.type) {
+    case 'SET': {
+      const { value, historyCapacity, undoCapacity } = action.payload;
+      const newHistory = [...state.history.slice(0, state.currentIndex + 1), value];
+      if (historyCapacity && newHistory.length > historyCapacity) {
+        newHistory.shift();
+      }
+      const newUndoStack = [state.history, ...state.undoStack];
+      if (undoCapacity && newUndoStack.length > undoCapacity) {
+        newUndoStack.pop();
+      }
+      return {
+        history: newHistory,
+        currentIndex: newHistory.length - 1,
+        undoStack: newUndoStack,
+        redoStack: []
+      };
+    }
+    case 'UNDO': {
+      if (state.undoStack.length === 0) return state;
+      return {
+        history: state.undoStack[0],
+        currentIndex: state.undoStack[0].length - 1,
+        undoStack: state.undoStack.slice(1),
+        redoStack: [state.history, ...state.redoStack]
+      };
+    }
+    case 'REDO': {
+      if (state.redoStack.length === 0) return state;
+      return {
+        history: state.redoStack[0],
+        currentIndex: state.redoStack[0].length - 1,
+        undoStack: [state.history, ...state.undoStack],
+        redoStack: state.redoStack.slice(1)
+      };
+    }
+    case 'BACK': {
+      const { steps } = action.payload;
+      return {
+        ...state,
+        currentIndex: Math.max(0, state.currentIndex - steps)
+      };
+    }
+    case 'FORWARD': {
+      const { steps } = action.payload;
+      return {
+        ...state,
+        currentIndex: Math.min(state.currentIndex + steps, state.history.length - 1)
+      };
+    }
+    case 'RESET': {
+      const { initialValue, undoCapacity } = action.payload;
+      if (state.history.length === 1) return state;
+      const newUndoStack = [state.history, ...state.undoStack];
+      if (undoCapacity && newUndoStack.length > undoCapacity) {
+        newUndoStack.pop();
+      }
+      return {
+        history: [initialValue],
+        currentIndex: 0,
+        undoStack: newUndoStack,
+        redoStack: []
+      };
+    }
+    default:
+      throw new Error('Unsupported action type');
+  }
+}
 /**
  * @name useStateHistory
  * @description - Hook that manages state with history functionality
  * @category Utilities
  *
  * @param {Value} initialValue - The initial value to start the history with
- * @param {number} [maxSize=10] - Maximum number of history entries to keep
+ * @param {number} [historyCapacity=10] - Maximum number of history entries to keep
+ * @param {number} [undoCapacity=10] - Maximum number of undo actions to keep
  * @returns {UseStateHistoryReturn<Value>} Object containing current value, history array and control methods
  *
  * @example
- * const { value, history, index, set, back, forward, reset, undo } = useStateHistory(0);
+ * const { value, history, index, set, back, forward, reset, undo, redo, canUndo, canRedo, } = useStateHistory(0);
  */
-export const useStateHistory = (initialValue, maxSize) => {
-  const [value, setValue] = useState(initialValue);
-  const [history, setHistory] = useState([initialValue]);
-  const currentIndexRef = useRef(0);
-  const set = (value) => {
-    setHistory((prevHistory) => {
-      const newHistory = prevHistory.slice(0, currentIndexRef.current + 1);
-      newHistory.push(value);
-      if (maxSize && newHistory.length > maxSize) newHistory.shift();
-      currentIndexRef.current = newHistory.length - 1;
-      return newHistory;
+export const useStateHistory = (initialValue, historyCapacity, undoCapacity) => {
+  const [state, dispatch] = useReducer(stateHistoryReducer, {
+    history: [initialValue],
+    currentIndex: 0,
+    undoStack: [],
+    redoStack: []
+  });
+  const currentValue = useMemo(
+    () => state.history[state.currentIndex],
+    [state.history, state.currentIndex]
+  );
+  const canUndo = useMemo(() => state.undoStack.length > 0, [state.undoStack]);
+  const canRedo = useMemo(() => state.redoStack.length > 0, [state.redoStack]);
+  const set = useCallback(
+    (value) => {
+      dispatch({
+        type: 'SET',
+        payload: { value, historyCapacity, undoCapacity }
+      });
+    },
+    [historyCapacity, undoCapacity]
+  );
+  const undo = useCallback(() => {
+    dispatch({ type: 'UNDO' });
+  }, [canUndo]);
+  const redo = useCallback(() => {
+    dispatch({ type: 'REDO' });
+  }, [canRedo]);
+  const back = useCallback((steps = 1) => {
+    dispatch({ type: 'BACK', payload: { steps } });
+  }, []);
+  const forward = useCallback((steps = 1) => {
+    dispatch({ type: 'FORWARD', payload: { steps } });
+  }, []);
+  const reset = useCallback(() => {
+    dispatch({
+      type: 'RESET',
+      payload: { initialValue, undoCapacity }
     });
-    setValue(value);
-  };
-  const undo = () => {
-    if (currentIndexRef.current === 0) return;
-    currentIndexRef.current--;
-    setValue(history[currentIndexRef.current]);
-    setHistory((prevHistory) => prevHistory.slice(0, currentIndexRef.current + 1));
-  };
-  const back = (steps = 1) => {
-    if (currentIndexRef.current - steps < 0) return;
-    currentIndexRef.current -= steps;
-    setValue(history[currentIndexRef.current]);
-  };
-  const forward = (steps = 1) => {
-    if (currentIndexRef.current + steps >= history.length) return;
-    currentIndexRef.current += steps;
-    setValue(history[currentIndexRef.current]);
-  };
-  const reset = () => {
-    setValue(initialValue);
-    setHistory([initialValue]);
-    currentIndexRef.current = 0;
-  };
+  }, [initialValue, undoCapacity]);
   return {
-    history,
-    value,
+    history: state.history,
+    value: currentValue,
     set,
-    index: currentIndexRef.current,
+    index: state.currentIndex,
     back,
     forward,
     reset,
-    undo
+    undo,
+    redo,
+    canUndo,
+    canRedo
   };
 };

--- a/packages/core/src/bundle/hooks/useStateHistory/useStateHistory.js
+++ b/packages/core/src/bundle/hooks/useStateHistory/useStateHistory.js
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useReducer } from 'react';
-// Reducer функция
 function stateHistoryReducer(state, action) {
   switch (action.type) {
     case 'SET': {

--- a/packages/core/src/hooks/useStateHistory/useStateHistory.test.ts
+++ b/packages/core/src/hooks/useStateHistory/useStateHistory.test.ts
@@ -2,15 +2,18 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useStateHistory } from './useStateHistory';
 
-it('Should use use state history', () => {
+it('Should use useStateHistory', () => {
   const { result } = renderHook(() => useStateHistory(0));
   expect(result.current.value).toBe(0);
   expect(result.current.history).toEqual([0]);
   expect(result.current.index).toBe(0);
+  expect(result.current.canUndo).toBe(false);
+  expect(result.current.canRedo).toBe(false);
   expect(result.current.back).toBeTypeOf('function');
   expect(result.current.forward).toBeTypeOf('function');
   expect(result.current.reset).toBeTypeOf('function');
   expect(result.current.undo).toBeTypeOf('function');
+  expect(result.current.redo).toBeTypeOf('function');
 });
 
 it('Should update value and history when pushing new value', () => {
@@ -23,7 +26,15 @@ it('Should update value and history when pushing new value', () => {
   expect(result.current.index).toBe(1);
 });
 
-it('Should respect max size parameter', () => {
+it('Should change canUndo flag when pushing new value', () => {
+  const { result } = renderHook(() => useStateHistory(0));
+
+  act(() => result.current.set(1));
+
+  expect(result.current.canUndo).toBe(true);
+});
+
+it('Should respect history max size parameter', () => {
   const { result } = renderHook(() => useStateHistory(0, 3));
 
   act(() => {
@@ -74,4 +85,18 @@ it('Should undo last change', () => {
   expect(result.current.value).toBe(0);
   expect(result.current.history).toEqual([0]);
   expect(result.current.index).toBe(0);
+});
+
+it('Should redo last change', () => {
+  const { result } = renderHook(() => useStateHistory(0));
+
+  act(() => {
+    result.current.set(1);
+    result.current.undo();
+    result.current.redo();
+  });
+
+  expect(result.current.value).toBe(1);
+  expect(result.current.history).toEqual([0, 1]);
+  expect(result.current.index).toBe(1);
 });

--- a/packages/core/src/hooks/useStateHistory/useStateHistory.ts
+++ b/packages/core/src/hooks/useStateHistory/useStateHistory.ts
@@ -37,7 +37,6 @@ type StateHistoryAction<Value> =
     }
   | { type: 'UNDO' };
 
-// Состояние для reducer
 interface StateHistoryState<Value> {
   currentIndex: number;
   history: Value[];
@@ -45,7 +44,6 @@ interface StateHistoryState<Value> {
   undoStack: Value[][];
 }
 
-// Reducer функция
 function stateHistoryReducer<Value>(
   state: StateHistoryState<Value>,
   action: StateHistoryAction<Value>

--- a/packages/core/src/hooks/useStateHistory/useStateHistory.ts
+++ b/packages/core/src/hooks/useStateHistory/useStateHistory.ts
@@ -1,7 +1,11 @@
-import { useRef, useState } from 'react';
+import { useCallback, useMemo, useReducer } from 'react';
 
 /** The use state history hook return type */
 interface UseStateHistoryReturn<Value> {
+  /** True if a redo operation can be performed */
+  canRedo: boolean;
+  /** True if an undo operation can be performed */
+  canUndo: boolean;
   /** All history values */
   history: Value[];
   /** Current index in history */
@@ -12,6 +16,8 @@ interface UseStateHistoryReturn<Value> {
   back: (steps?: number) => void;
   /** Go forward specified number of steps in history (default: 1) */
   forward: (steps?: number) => void;
+  /** Redo the last change */
+  redo: () => void;
   /** Reset history to initial state */
   reset: () => void;
   /** Set a new value */
@@ -20,70 +26,188 @@ interface UseStateHistoryReturn<Value> {
   undo: () => void;
 }
 
+type StateHistoryAction<Value> =
+  | { type: 'BACK'; payload: { steps: number } }
+  | { type: 'FORWARD'; payload: { steps: number } }
+  | { type: 'REDO' }
+  | { type: 'RESET'; payload: { initialValue: Value; undoCapacity?: number } }
+  | {
+      type: 'SET';
+      payload: { value: Value; historyCapacity?: number; undoCapacity?: number };
+    }
+  | { type: 'UNDO' };
+
+// Состояние для reducer
+interface StateHistoryState<Value> {
+  currentIndex: number;
+  history: Value[];
+  redoStack: Value[][];
+  undoStack: Value[][];
+}
+
+// Reducer функция
+function stateHistoryReducer<Value>(
+  state: StateHistoryState<Value>,
+  action: StateHistoryAction<Value>
+): StateHistoryState<Value> {
+  switch (action.type) {
+    case 'SET': {
+      const { value, historyCapacity, undoCapacity } = action.payload;
+
+      const newHistory = [...state.history.slice(0, state.currentIndex + 1), value];
+      if (historyCapacity && newHistory.length > historyCapacity) {
+        newHistory.shift();
+      }
+
+      const newUndoStack = [state.history, ...state.undoStack];
+      if (undoCapacity && newUndoStack.length > undoCapacity) {
+        newUndoStack.pop();
+      }
+
+      return {
+        history: newHistory,
+        currentIndex: newHistory.length - 1,
+        undoStack: newUndoStack,
+        redoStack: []
+      };
+    }
+
+    case 'UNDO': {
+      if (state.undoStack.length === 0) return state;
+
+      return {
+        history: state.undoStack[0],
+        currentIndex: state.undoStack[0].length - 1,
+        undoStack: state.undoStack.slice(1),
+        redoStack: [state.history, ...state.redoStack]
+      };
+    }
+
+    case 'REDO': {
+      if (state.redoStack.length === 0) return state;
+
+      return {
+        history: state.redoStack[0],
+        currentIndex: state.redoStack[0].length - 1,
+        undoStack: [state.history, ...state.undoStack],
+        redoStack: state.redoStack.slice(1)
+      };
+    }
+
+    case 'BACK': {
+      const { steps } = action.payload;
+      return {
+        ...state,
+        currentIndex: Math.max(0, state.currentIndex - steps)
+      };
+    }
+
+    case 'FORWARD': {
+      const { steps } = action.payload;
+      return {
+        ...state,
+        currentIndex: Math.min(state.currentIndex + steps, state.history.length - 1)
+      };
+    }
+
+    case 'RESET': {
+      const { initialValue, undoCapacity } = action.payload;
+      if (state.history.length === 1) return state;
+
+      const newUndoStack = [state.history, ...state.undoStack];
+      if (undoCapacity && newUndoStack.length > undoCapacity) {
+        newUndoStack.pop();
+      }
+
+      return {
+        history: [initialValue],
+        currentIndex: 0,
+        undoStack: newUndoStack,
+        redoStack: []
+      };
+    }
+
+    default:
+      throw new Error('Unsupported action type');
+  }
+}
+
 /**
  * @name useStateHistory
  * @description - Hook that manages state with history functionality
  * @category Utilities
  *
  * @param {Value} initialValue - The initial value to start the history with
- * @param {number} [maxSize=10] - Maximum number of history entries to keep
+ * @param {number} [historyCapacity=10] - Maximum number of history entries to keep
+ * @param {number} [undoCapacity=10] - Maximum number of undo actions to keep
  * @returns {UseStateHistoryReturn<Value>} Object containing current value, history array and control methods
  *
  * @example
- * const { value, history, index, set, back, forward, reset, undo } = useStateHistory(0);
+ * const { value, history, index, set, back, forward, reset, undo, redo, canUndo, canRedo, } = useStateHistory(0);
  */
 export const useStateHistory = <Value>(
   initialValue: Value,
-  maxSize?: number
+  historyCapacity?: number,
+  undoCapacity?: number
 ): UseStateHistoryReturn<Value> => {
-  const [value, setValue] = useState<Value>(initialValue);
-  const [history, setHistory] = useState<Value[]>([initialValue]);
-  const currentIndexRef = useRef<number>(0);
+  const [state, dispatch] = useReducer(stateHistoryReducer<Value>, {
+    history: [initialValue],
+    currentIndex: 0,
+    undoStack: [],
+    redoStack: []
+  });
 
-  const set = (value: Value) => {
-    setHistory((prevHistory) => {
-      const newHistory = prevHistory.slice(0, currentIndexRef.current + 1);
-      newHistory.push(value);
-      if (maxSize && newHistory.length > maxSize) newHistory.shift();
-      currentIndexRef.current = newHistory.length - 1;
-      return newHistory;
+  const currentValue = useMemo(
+    () => state.history[state.currentIndex],
+    [state.history, state.currentIndex]
+  );
+  const canUndo = useMemo(() => state.undoStack.length > 0, [state.undoStack]);
+  const canRedo = useMemo(() => state.redoStack.length > 0, [state.redoStack]);
+
+  const set = useCallback(
+    (value: Value) => {
+      dispatch({
+        type: 'SET',
+        payload: { value, historyCapacity, undoCapacity }
+      });
+    },
+    [historyCapacity, undoCapacity]
+  );
+
+  const undo = useCallback(() => {
+    dispatch({ type: 'UNDO' });
+  }, [canUndo]);
+
+  const redo = useCallback(() => {
+    dispatch({ type: 'REDO' });
+  }, [canRedo]);
+
+  const back = useCallback((steps = 1) => {
+    dispatch({ type: 'BACK', payload: { steps } });
+  }, []);
+
+  const forward = useCallback((steps: number = 1) => {
+    dispatch({ type: 'FORWARD', payload: { steps } });
+  }, []);
+
+  const reset = useCallback(() => {
+    dispatch({
+      type: 'RESET',
+      payload: { initialValue, undoCapacity }
     });
-    setValue(value);
-  };
-
-  const undo = () => {
-    if (currentIndexRef.current === 0) return;
-    currentIndexRef.current--;
-    setValue(history[currentIndexRef.current]);
-    setHistory((prevHistory) => prevHistory.slice(0, currentIndexRef.current + 1));
-  };
-
-  const back = (steps: number = 1) => {
-    if (currentIndexRef.current - steps < 0) return;
-    currentIndexRef.current -= steps;
-    setValue(history[currentIndexRef.current]);
-  };
-
-  const forward = (steps: number = 1) => {
-    if (currentIndexRef.current + steps >= history.length) return;
-    currentIndexRef.current += steps;
-    setValue(history[currentIndexRef.current]);
-  };
-
-  const reset = () => {
-    setValue(initialValue);
-    setHistory([initialValue]);
-    currentIndexRef.current = 0;
-  };
+  }, [initialValue, undoCapacity]);
 
   return {
-    history,
-    value,
+    history: state.history,
+    value: currentValue,
     set,
-    index: currentIndexRef.current,
+    index: state.currentIndex,
     back,
     forward,
     reset,
-    undo
+    undo,
+    redo,
+    canUndo,
+    canRedo
   };
 };


### PR DESCRIPTION
Решение issue #338 [useStateHistory] incorrect undo behavior

### Основные изменения хука **useStateHistory**

Дисклеймер:
Я пока не обновил файл `useHistoryState.js` (оказалось обновлял, но я не проверял еще его). И я знаю что тесты пока покрывают мало сценариев.

**НОВОЕ**
1. Метод `undo()` теперь откатывает назад последнее изменение `history`. А раньше удалял последний эл-т.
2. Новый метод `redo()` позволяет вернуть изменения которые сделаны через `undo()`
Для реализации undo/redo создал в стейте массивы `undoStack` и `redoStack`, которые хранят историю состояний `history`.
3. Добаивил 3-й опциональный параметр `undoCapacity` для вызова хука `useStateHistory()`, который ограничивает сколько состояний хранится для `undo()`.
4. Добавил флаги `canUndo` и `canRedo`, которые возвращаются при вызове хука.

**ИЗМЕНЕНИЯ**
1. Перевел всю логику с `useState` на `useReducer`, чтобы избегать проблем и багов при работе с несколькими `useState`. Из-за батчинга были проблемы с актуальными значениями переменных.
2. Изменил название принимаемого параметра `maxSize` на `historyCapacity`

**EXTRA МОМЕНТЫ**
**Первое**
Были мысли соединить undoStack и redoStack в один массив и перемещаться по нему для undo() и redo(). Если это важно, могу его перенести на такой вариант.
**Второе**
Для контроля размера истории `historyCapacity` и `undoCapacity` сейчас мы используем простой `pop()` и `shift()` и  эффективность такого подхода **O(n)**. Если оч важна эффективность то есть идея попробовать **ring buffer** который сведет эффективность контроля размера к **O(1)**, но для этого скорее всего нужно будет создать отдельный класс с реализацией ring buffer
