### PR TITLE
cli-case 🧊 add case setting in cli

### DIFF
--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -43,7 +43,8 @@ export const init = async () => {
       aliases: {
         hooks: '@/shared/hooks',
         utils: '@/utils/lib'
-      }
+      },
+      case: 'camel'
     };
     await fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
     console.log(JSON.stringify(config, null, 2));

--- a/packages/cli/src/utils/helpers/index.ts
+++ b/packages/cli/src/utils/helpers/index.ts
@@ -1,2 +1,4 @@
-export * from './getConfig';
-export * from './getPackageManager';
+export * from "./getConfig";
+export * from "./getPackageManager";
+export * from "./toKebabCase";
+export * from "./toCase";

--- a/packages/cli/src/utils/helpers/toCase.ts
+++ b/packages/cli/src/utils/helpers/toCase.ts
@@ -1,0 +1,4 @@
+import { toKebabCase } from "./toKebabCase";
+
+export const toCase = (string: string, mode: "camel" | "kebab" = "camel") =>
+  mode === "camel" ? string : toKebabCase(string);

--- a/packages/cli/src/utils/helpers/toKebabCase.ts
+++ b/packages/cli/src/utils/helpers/toKebabCase.ts
@@ -1,0 +1,5 @@
+export const toKebabCase = (string: string) =>
+  string.replace(
+    /[A-Z]+(?![a-z])|[A-Z]/g,
+    (match, offset) => (offset ? "-" : "") + match.toLowerCase()
+  );

--- a/packages/cli/src/utils/types/index.ts
+++ b/packages/cli/src/utils/types/index.ts
@@ -27,7 +27,8 @@ export const configSchema = z
     aliases: z.object({
       hooks: z.string(),
       utils: z.string()
-    })
+    }),
+    case: z.literal(['camel', 'kebab']).optional()
   })
   .strict();
 

--- a/packages/docs/app/reactuse-json.md
+++ b/packages/docs/app/reactuse-json.md
@@ -28,7 +28,7 @@ Setting this option to `false` allows hooks to be added as JavaScript with the `
 
 ```json title="reactuse.json"
 {
-  "ts": "true | false"
+  "ts": true | false
 }
 ```
 
@@ -64,5 +64,20 @@ Import alias for your hooks.
   "aliases": {
     "hooks": "@/shared/hooks"
   }
+}
+```
+
+## case
+
+Controls the naming convention for generated files.
+
+There are two options:
+
+- `camel`: All files will be generated in `camelCase` (e.g., `useClickOutside.ts`).
+- `kebab`: All files will be generated in `kebab-case` (e.g., `use-click-outside.ts`).
+
+```json title="reactuse.json"
+{
+  "case": "camel" | "kebab"
 }
 ```


### PR DESCRIPTION
#411

Добавил возможность добавлять хуки в `kebab-case`

1. Сложность была придумать `regex` для импорта смежных хуков/утилит, остановился на таком варианте: `/import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"](\.[^'"]*)['"]/g`. Он вычисляет все импорты (в т.ч. импорты типов), которые начинаются с такого пути `./`. Соответственно кейсы `../`, `../..` и прочие уже продуманы
2. Также добавил функцию `toKebabCase`, но не добавил функцию `toCamelCase`, т.к. кажется это излишним, потому что весь проект в `camelCase` и проблем возникнуть не должно
3. Также пока тестил, нашел баг: при установке `useDocumentEvent` скрипт падает из-за 404 ошибки на бэке, он пытается найти файл `utils/helpers/target`, хотя его не сущетсвует, этот путь складывается из-за того что в файле `utils/helpers/isTarget` есть переменная `target` и алгоритм выстраивает такой путь (`utils/helpers/target`,) до неё, стоит наверное вынести эту переменную в отдельный файлик