### PR TITLE
[fix] fix docs build

### DIFF
--- a/packages/docs/app/.vitepress/config.mts
+++ b/packages/docs/app/.vitepress/config.mts
@@ -33,18 +33,7 @@ export default async () => {
     description:
       'Improve your react applications with our library 📦 designed for comfort and speed',
     markdown: {
-      codeTransformers: [
-        transformerTwoslash({
-          twoslashOptions: {
-            compilerOptions: {
-              baseUrl: fileURLToPath(new URL('.', import.meta.url)),
-              paths: {
-                '@siberiacancode/reactuse': ['../../../core/src/index.ts']
-              }
-            }
-          }
-        })
-      ],
+      codeTransformers: [transformerTwoslash()],
       languages: ['js', 'jsx', 'ts', 'tsx']
     } as unknown as MarkdownOptions,
     vite: {

--- a/packages/docs/app/target.md
+++ b/packages/docs/app/target.md
@@ -5,6 +5,7 @@
 Many `React` libraries that work with DOM elements typically support only one way of providing target elements - usually through refs.
 
 ```typescript twoslash
+// @errors: 2307
 import { useClickOutside } from '@siberiacancode/reactuse';
 import { useRef } from 'react';
 
@@ -21,6 +22,7 @@ Our library implements a flexible approach using `typescript` function overloads
 1. By passing an **existing** target _(ref, DOM element, function that returns a DOM element, or selector)_
 
 ```typescript twoslash
+// @errors: 2307
 import { useClickOutside } from '@siberiacancode/reactuse';
 import { useRef } from 'react';
 
@@ -31,6 +33,7 @@ useClickOutside(ref, () => console.log('Clicked outside'));
 or you can use [target](#the-target-function) function
 
 ```typescript twoslash
+// @errors: 2307
 import { target, useClickOutside } from '@siberiacancode/reactuse';
 
 useClickOutside(target('#container'), () => console.log('Clicked outside'));
@@ -39,6 +42,7 @@ useClickOutside(target('#container'), () => console.log('Clicked outside'));
 2. By receiving a ref callback that can be attached to an element
 
 ```typescript twoslash
+// @errors: 2307
 import { useClickOutside } from '@siberiacancode/reactuse';
 
 const ref = useClickOutside<HTMLDivElement>(() => console.log('Clicked outside'));
@@ -58,6 +62,7 @@ The `target` is a utility function that helps you work with DOM elements in a fl
 The flexibility of `target` means you can use our hooks like you want.
 
 ```typescript twoslash
+// @errors: 2307
 import { target, useClickOutside } from '@siberiacancode/reactuse';
 
 useClickOutside(target('#container'), () => console.log('Clicked outside'));


### PR DESCRIPTION
before:
```bash
Total: 158 elements

  vitepress v1.6.4

⠼ building client + server bundles...

--------
Twoslash error in code:
--------
import { useClickOutside } from '@siberiacancode/reactuse';
import { useRef } from 'react';

const ref = useRef<HTMLDivElement>(null);
useClickOutside(ref, () => console.log('Clicked outside'));
--------

x Build failed in 2.65s
✖ building client + server bundles...
build error:
[vitepress] 
## Errors were thrown in the sample, but not included in an error tag

These errors were not marked as being expected: 2307.
Expected: // @errors: 2307

Compiler Errors:

index.ts
  [2307] 32 - Cannot find module '@siberiacancode/reactuse' or its corresponding type declarations.

[vitepress] 
## Errors were thrown in the sample, but not included in an error tag

These errors were not marked as being expected: 2307.
Expected: // @errors: 2307

Compiler Errors:

index.ts
  [2307] 32 - Cannot find module '@siberiacancode/reactuse' or its corresponding type declarations.
```

after:
```
> @siberiacancode/docs@1.0.0 preview E:\web\reactuse\packages\docs
> vitepress preview app


Elements injection report

Injected: 158
Test coverage: 72% (113)
Untested: useDropZone, useEventSource, useEyeDropper, useField, useFileDialog, useFocusTrap, useFullscreen, useGamepad, useHotkeys, useInfiniteScroll, useKeyPress, useKeyPressEvent, useKeyboard, useKeysPressed, useLongPress, useMediaControls, useMouse, useOtpCredential, usePaint,iteScroll, useKeyPress, useKeyPress useParallax, usePerformanceObserver, usePermission, usePictureInPicture, usePointerLock, usePostMessage, usePreferredColorScheme, usePreferr, usePermission, usePictureInPicturedContrast, useRaf, useRightClick, useScroll, useScrollIntoView, useScrollTo, useSpeechRecognition, useSpeechSynthesis, useSticky, useStoracrollTo, useSpeechRecognition, useSge, useTextSelection, useTextareaAutosize, useUrlSearchParam, useUrlSearchParams, useVirtualKeyboard, useWakeLock, useWebSocket, useWindowFoWakeLock, useWebSocket, useWindowFocus, useWindowScroll
Skipped: 0

Total: 158 elements
Built site served at http://localhost:4173/reactuse/
```