### PR TITLE
fix(createStore): Возврат изначального значения при вызове getInitialState

### DIFF
--- a/packages/core/src/helpers/createStore/createStore.test.ts
+++ b/packages/core/src/helpers/createStore/createStore.test.ts
@@ -132,3 +132,11 @@ it('Should work correct with array state', () => {
   store.set([1, 2, 3]);
   expect(store.get()).toEqual([1, 2, 3]);
 });
+
+it('Should return initial state after state changes', () => {
+  const counterStore = createStore<number>(0)
+
+  counterStore.set(1)
+
+  expect(store.getInitialState()).toEqual(0)
+})


### PR DESCRIPTION
До этого getInitialState возвращал не изначальный стейт, а актуальный + возвращаемый тип не соответствовал returns из jsdoc. Скрины до и после прикладываю.

<img width="1530" height="1094" alt="Снимок экрана 2026-01-04 в 13 48 26" src="https://github.com/user-attachments/assets/332a3744-7248-4bff-ad73-192c8562240f" />


<img width="1310" height="736" alt="Снимок экрана 2026-01-04 в 13 53 44" src="https://github.com/user-attachments/assets/b32788e8-9d1e-4f6b-b170-5fc2c584fcb7" />
