### PR TITLE
fix/auto-scroll-demo 🧊 properly destructure ref from useAutoScroll hook

### DIFF
--- a/packages/core/src/hooks/useAutoScroll/useAutoScroll.demo.tsx
+++ b/packages/core/src/hooks/useAutoScroll/useAutoScroll.demo.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 const Demo = () => {
   const [messages, setMessages] = useState([`Message 1 at ${new Date().toLocaleTimeString()}`]);
 
-  const listRef = useAutoScroll<HTMLUListElement>();
+  const { ref: listRef } = useAutoScroll<HTMLUListElement>();
 
   const onAddMessage = () =>
     setMessages((prev) => [


### PR DESCRIPTION
## Description

Properly destructured `ref` from `useAutoScroll` hook in the Demo example.

Previously, the hook result was assigned directly to a variable, which broke auto-scroll.

Fixes #438 