### PR TITLE
[fix]: useClickOutside 🧊 Properly destructure ref in useClickOutside demo

### DIFF
--- a/packages/core/src/hooks/useClickOutside/useClickOutside.demo.tsx
+++ b/packages/core/src/hooks/useClickOutside/useClickOutside.demo.tsx
@@ -4,7 +4,7 @@ import { useClickOutside, useCounter } from '@siberiacancode/reactuse';
 const Demo = () => {
   const counter = useCounter();
 
-  const clickOutsideRef = useClickOutside<HTMLDivElement>(() => {
+  const { ref: clickOutsideRef } = useClickOutside<HTMLDivElement>(() => {
     console.log('click outside');
     counter.inc();
   });


### PR DESCRIPTION
Properly destructured `ref` from `useClickOutside` hook in the Demo example.

Previously, the hook result was assigned directly to a variable, which broke click counts.

Fixes #441 