### PR TITLE
[fix]: useDoubleClick 🧊 Properly destructure ref in useDoubleClick demo

### DIFF
--- a/packages/core/src/hooks/useDoubleClick/useDoubleClick.demo.tsx
+++ b/packages/core/src/hooks/useDoubleClick/useDoubleClick.demo.tsx
@@ -2,7 +2,7 @@ import { useCounter, useDoubleClick } from '@siberiacancode/reactuse';
 
 const Demo = () => {
   const counter = useCounter();
-  const doubleClickRef = useDoubleClick<HTMLButtonElement>(() => counter.inc());
+  const { ref: doubleClickRef } = useDoubleClick<HTMLButtonElement>(() => counter.inc());
 
   return (
     <>


### PR DESCRIPTION
Properly destructured `ref` from `useDoubleClick` hook in the Demo example.

Previously, the hook result was assigned directly to a variable, which broke click counts.

Fixes #443 