### PR TITLE
fix/useAync-demo 🧊 Fixed useAsync demo skeleton not proper rendering

### DIFF
--- a/packages/core/src/hooks/useAsync/useAsync.demo.tsx
+++ b/packages/core/src/hooks/useAsync/useAsync.demo.tsx
@@ -21,14 +21,14 @@ const Demo = () => {
         Next
       </button>
 
-      {getPokemonQuery.data && !getPokemonQuery.isLoading && (
+      {getPokemonQuery.isLoading && (
         <div className='flex animate-pulse flex-col gap-2'>
           <div className='h-7 w-40 rounded-md bg-neutral-600' />
           <div className='size-96 rounded-md bg-neutral-600' />
         </div>
       )}
 
-      {getPokemonQuery.data && (
+      {getPokemonQuery.data && !getPokemonQuery.isLoading && (
         <div className='flex flex-col gap-2'>
           <p>
             Name: <code>{getPokemonQuery.data.name}</code>


### PR DESCRIPTION
The previous `useAsync` demo skeleton render condition was:
```ts
getPokemonQuery.data && !getPokemonQuery.isLoading &&
```
which is litterly mean to show loading skeleton when data is not loading.

</br>

Solution in this pull request is fixes this and renders loading skeleton on every data request.

Alternatively we can use this code to render skeleton only ones for data's first fetch:
```ts
{!getPokemonQuery.data && getPokemonQuery.isLoading && (
        {/* LOADING SKELETON */}
      )}

      {getPokemonQuery.data && (
       {/* DATA */}
      )}
```

Fixes #445 