### PR TITLE
fix(docs): resolved markdown for function Copy Page

### DIFF
--- a/packages/newdocs/app/(docs)/functions/[[...slug]]/page.tsx
+++ b/packages/newdocs/app/(docs)/functions/[[...slug]]/page.tsx
@@ -67,15 +67,20 @@ const FunctionPage = async (props: FunctionPageProps) => {
 
   const doc = page.data;
   const neighbours = findNeighbour(functionsSource.pageTree, page.url);
-  const raw = await doc.getText('raw');
   const lastModifiedTime = doc.lastModifiedTime;
 
-  const metadata = JSON.parse(
-    await fs.readFile(
-      path.join(process.cwd(), 'content', 'functions', `${doc.type}s`, `${doc.title}.meta.json`),
+  const [metadata, markdown] = await Promise.all([
+    fs
+      .readFile(
+        path.join(process.cwd(), 'content', 'functions', `${doc.type}s`, `${doc.title}.meta.json`),
+        'utf-8'
+      )
+      .then((content) => JSON.parse(content) as FunctionMetadata),
+    fs.readFile(
+      path.join(process.cwd(), 'public', 'functions', `${doc.type}s`, `${doc.title}.md`),
       'utf-8'
     )
-  ) as FunctionMetadata;
+  ]);
 
   const MDX = doc.body;
 
@@ -90,7 +95,7 @@ const FunctionPage = async (props: FunctionPageProps) => {
             category={doc.category}
             description={doc.description}
             isTest={doc.isTest}
-            markdown={raw}
+            markdown={markdown}
             name={doc.title}
             next={neighbours.next?.url}
             previous={neighbours.previous?.url}

--- a/packages/newdocs/scripts/generate-functions.ts
+++ b/packages/newdocs/scripts/generate-functions.ts
@@ -163,8 +163,8 @@ interface ShareMarkdownPage {
     name?: string;
   };
   category: string;
+  contributors: FunctionMetadata['contributors'];
   demo?: string;
-  dependencies: FunctionMetadata['dependencies'];
   description: string;
   examples: string[];
   isTest: boolean;
@@ -179,6 +179,8 @@ interface ShareMarkdownPage {
 const createCodeFence = (language: string, code: string) =>
   `\`\`\`${language}\n${code.trimEnd()}\n\`\`\``;
 
+// Mirrors the interactive function page section order (like shadcn share md):
+// banner/demo → Installation (library / cli / manual+source) → Usage → Type Declarations → API → Contributors
 const createShareMarkdown = (page: ShareMarkdownPage) => {
   const lines: string[] = [];
 
@@ -211,22 +213,23 @@ const createShareMarkdown = (page: ShareMarkdownPage) => {
     lines.push('');
   }
 
+  // FunctionBanner on the page: demo code first, no extra heading (shadcn-style).
+  if (page.demo?.trim()) {
+    lines.push(createCodeFence('tsx', page.demo));
+    lines.push('');
+  }
+
   lines.push('## Installation');
-  lines.push('');
-  lines.push('Library:');
   lines.push('');
   lines.push(createCodeFence('bash', 'npm install @siberiacancode/reactuse'));
   lines.push('');
-  lines.push('CLI:');
-  lines.push('');
   lines.push(createCodeFence('bash', `npx useverse@latest add ${page.name}`));
   lines.push('');
-  lines.push('Manual: copy the source below into your project and update import paths.');
-  lines.push('');
-
-  lines.push('## Source');
+  lines.push('Copy and paste the following code into your project.');
   lines.push('');
   lines.push(createCodeFence('ts', page.source));
+  lines.push('');
+  lines.push('Update the import paths to match your project setup.');
   lines.push('');
 
   lines.push('## Usage');
@@ -236,6 +239,13 @@ const createShareMarkdown = (page: ShareMarkdownPage) => {
     .join('\n');
   lines.push(createCodeFence('tsx', usage));
   lines.push('');
+
+  if (page.typeDeclarations?.trim()) {
+    lines.push('## Type Declarations');
+    lines.push('');
+    lines.push(createCodeFence('ts', page.typeDeclarations));
+    lines.push('');
+  }
 
   if (page.apiParameters.length) {
     lines.push('## API');
@@ -269,32 +279,11 @@ const createShareMarkdown = (page: ShareMarkdownPage) => {
     lines.push('');
   }
 
-  if (page.typeDeclarations?.trim()) {
-    lines.push('## Type Declarations');
+  if (page.contributors.length) {
+    lines.push('## Contributors');
     lines.push('');
-    lines.push(createCodeFence('ts', page.typeDeclarations));
-    lines.push('');
-  }
-
-  if (page.demo?.trim()) {
-    lines.push('## Demo');
-    lines.push('');
-    lines.push(createCodeFence('tsx', page.demo));
-    lines.push('');
-  }
-
-  const { hooks, utils, packages } = page.dependencies;
-  if (hooks.length || utils.length || packages.length) {
-    lines.push('## Dependencies');
-    lines.push('');
-    if (hooks.length) {
-      lines.push(`- **Hooks:** ${hooks.map((item) => `\`${item}\``).join(', ')}`);
-    }
-    if (utils.length) {
-      lines.push(`- **Utils:** ${utils.map((item) => `\`${item}\``).join(', ')}`);
-    }
-    if (packages.length) {
-      lines.push(`- **Packages:** ${packages.map((item) => `\`${item}\``).join(', ')}`);
+    for (const contributor of page.contributors) {
+      lines.push(`- ${contributor.name}`);
     }
     lines.push('');
   }
@@ -562,7 +551,7 @@ const init = async () => {
         isTest: page.isTest,
         examples: page.examples,
         apiParameters: page.apiParameters,
-        dependencies: page.dependencies,
+        contributors: page.contributors,
         source,
         ...(page.warning && { warning: page.warning }),
         ...(page.browserapi && {

--- a/packages/newdocs/scripts/generate-functions.ts
+++ b/packages/newdocs/scripts/generate-functions.ts
@@ -179,6 +179,77 @@ interface ShareMarkdownPage {
 const createCodeFence = (language: string, code: string) =>
   `\`\`\`${language}\n${code.trimEnd()}\n\`\`\``;
 
+const escapeMarkdownTableCell = (value: string) =>
+  value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+
+// Matches FunctionApi on the page: overload groups with Parameters table + Returns.
+const createShareApiMarkdown = (apiParameters: FunctionMetadata['apiParameters']) => {
+  let groupIndex = 0;
+  const groups: {
+    parameters: FunctionMetadata['apiParameters'];
+    returns: FunctionMetadata['apiParameters'][number] | null;
+  }[] = [{ parameters: [], returns: null }];
+
+  apiParameters.forEach((parameter, index) => {
+    if (parameter.tag === 'overload') {
+      const isFirstOverload = apiParameters.findIndex(({ tag }) => tag === 'overload') === index;
+
+      if (!isFirstOverload) {
+        groupIndex++;
+        groups.push({ parameters: [], returns: null });
+      }
+
+      return;
+    }
+
+    if (parameter.tag === 'returns') {
+      groups[groupIndex]!.returns = parameter;
+      return;
+    }
+
+    groups[groupIndex]!.parameters.push(parameter);
+  });
+
+  const lines: string[] = [];
+
+  groups.forEach((group, index) => {
+    if (group.parameters.length) {
+      lines.push('### Parameters');
+      lines.push('');
+      lines.push('| Name | Type | Default | Note |');
+      lines.push('| --- | --- | --- | --- |');
+
+      for (const parameter of group.parameters) {
+        const name = escapeMarkdownTableCell(parameter.name);
+        const type = escapeMarkdownTableCell(parameter.type || 'unknown');
+        const defaultValue = escapeMarkdownTableCell(parameter.default ?? '-');
+        const note = escapeMarkdownTableCell(parameter.description || '');
+        lines.push(`| ${name} | \`${type}\` | ${defaultValue} | ${note} |`);
+      }
+
+      lines.push('');
+    }
+
+    if (group.returns) {
+      lines.push('### Returns');
+      lines.push('');
+      lines.push('`' + (group.returns.type || 'unknown') + '`');
+      if (group.returns.description) {
+        lines.push('');
+        lines.push(group.returns.description);
+      }
+      lines.push('');
+    }
+
+    if (index < groups.length - 1) {
+      lines.push('---');
+      lines.push('');
+    }
+  });
+
+  return lines;
+};
+
 // Mirrors the interactive function page section order (like shadcn share md):
 // banner/demo → Installation (library / cli / manual+source) → Usage → Type Declarations → API → Contributors
 const createShareMarkdown = (page: ShareMarkdownPage) => {
@@ -250,33 +321,7 @@ const createShareMarkdown = (page: ShareMarkdownPage) => {
   if (page.apiParameters.length) {
     lines.push('## API');
     lines.push('');
-
-    for (const parameter of page.apiParameters) {
-      if (parameter.tag === 'overload') {
-        lines.push('- **Overload**');
-        continue;
-      }
-
-      if (parameter.tag === 'param') {
-        const optional = parameter.optional ? '?' : '';
-        const defaultValue =
-          parameter.default !== undefined && parameter.default !== ''
-            ? ` = ${parameter.default}`
-            : '';
-        const type = parameter.type || 'unknown';
-        const description = parameter.description ? ` — ${parameter.description}` : '';
-        lines.push(`- \`${parameter.name}${optional}: ${type}${defaultValue}\`${description}`);
-        continue;
-      }
-
-      if (parameter.tag === 'returns') {
-        const type = parameter.type || 'unknown';
-        const description = parameter.description ? ` — ${parameter.description}` : '';
-        lines.push(`- **Returns:** \`${type}\`${description}`);
-      }
-    }
-
-    lines.push('');
+    lines.push(...createShareApiMarkdown(page.apiParameters));
   }
 
   if (page.contributors.length) {

--- a/packages/newdocs/scripts/generate-functions.ts
+++ b/packages/newdocs/scripts/generate-functions.ts
@@ -298,7 +298,7 @@ const createShareMarkdown = (page: ShareMarkdownPage) => {
   lines.push('');
   lines.push('Copy and paste the following code into your project.');
   lines.push('');
-  lines.push(createCodeFence('ts', page.source));
+  lines.push(createCodeFence('tsx', page.source));
   lines.push('');
   lines.push('Update the import paths to match your project setup.');
   lines.push('');
@@ -314,7 +314,7 @@ const createShareMarkdown = (page: ShareMarkdownPage) => {
   if (page.typeDeclarations?.trim()) {
     lines.push('## Type Declarations');
     lines.push('');
-    lines.push(createCodeFence('ts', page.typeDeclarations));
+    lines.push(createCodeFence('tsx', page.typeDeclarations));
     lines.push('');
   }
 

--- a/packages/newdocs/scripts/generate-functions.ts
+++ b/packages/newdocs/scripts/generate-functions.ts
@@ -6,7 +6,7 @@ import ts from 'typescript';
 
 import type { CodeLanguage, FunctionMetadata } from '@/src/constants';
 
-import { CONTENT_ROOT, CORE_ROOT } from './constants';
+import { CONTENT_ROOT, CORE_ROOT, PUBLIC_ROOT } from './constants';
 import {
   checkFileContent,
   extractDependencies,
@@ -154,6 +154,152 @@ const createMdxTemplate = (metadata: FunctionMetadata) => {
   result.push(`<FunctionContributors contributors={metadata.contributors} />`);
 
   return result.join('\n');
+};
+
+interface ShareMarkdownPage {
+  apiParameters: FunctionMetadata['apiParameters'];
+  browserapi?: {
+    description?: string;
+    name?: string;
+  };
+  category: string;
+  demo?: string;
+  dependencies: FunctionMetadata['dependencies'];
+  description: string;
+  examples: string[];
+  isTest: boolean;
+  name: string;
+  source: string;
+  type: FunctionMetadata['type'];
+  typeDeclarations?: string;
+  usage: string;
+  warning?: string;
+}
+
+const createCodeFence = (language: string, code: string) =>
+  `\`\`\`${language}\n${code.trimEnd()}\n\`\`\``;
+
+const createShareMarkdown = (page: ShareMarkdownPage) => {
+  const lines: string[] = [];
+
+  lines.push('---');
+  lines.push(`title: ${page.name}`);
+  if (page.description) lines.push(`description: ${page.description}`);
+  lines.push(`category: ${page.category.toLowerCase()}`);
+  lines.push(`usage: ${page.usage.toLowerCase()}`);
+  lines.push(`type: ${page.type}`);
+  lines.push(`isTest: ${page.isTest}`);
+  if (page.browserapi?.name) {
+    lines.push(
+      page.browserapi.description
+        ? `browserapi: ${page.browserapi.name} ${page.browserapi.description}`
+        : `browserapi: ${page.browserapi.name}`
+    );
+  }
+  lines.push('---');
+  lines.push('');
+  lines.push(`# ${page.name}`);
+  lines.push('');
+
+  if (page.description) {
+    lines.push(page.description);
+    lines.push('');
+  }
+
+  if (page.warning) {
+    lines.push(`> **Warning:** ${page.warning}`);
+    lines.push('');
+  }
+
+  lines.push('## Installation');
+  lines.push('');
+  lines.push('Library:');
+  lines.push('');
+  lines.push(createCodeFence('bash', 'npm install @siberiacancode/reactuse'));
+  lines.push('');
+  lines.push('CLI:');
+  lines.push('');
+  lines.push(createCodeFence('bash', `npx useverse@latest add ${page.name}`));
+  lines.push('');
+  lines.push('Manual: copy the source below into your project and update import paths.');
+  lines.push('');
+
+  lines.push('## Source');
+  lines.push('');
+  lines.push(createCodeFence('ts', page.source));
+  lines.push('');
+
+  lines.push('## Usage');
+  lines.push('');
+  const usage = page.examples
+    .map((example, index) => (index === 0 ? example : `// or\n${example}`))
+    .join('\n');
+  lines.push(createCodeFence('tsx', usage));
+  lines.push('');
+
+  if (page.apiParameters.length) {
+    lines.push('## API');
+    lines.push('');
+
+    for (const parameter of page.apiParameters) {
+      if (parameter.tag === 'overload') {
+        lines.push('- **Overload**');
+        continue;
+      }
+
+      if (parameter.tag === 'param') {
+        const optional = parameter.optional ? '?' : '';
+        const defaultValue =
+          parameter.default !== undefined && parameter.default !== ''
+            ? ` = ${parameter.default}`
+            : '';
+        const type = parameter.type || 'unknown';
+        const description = parameter.description ? ` — ${parameter.description}` : '';
+        lines.push(`- \`${parameter.name}${optional}: ${type}${defaultValue}\`${description}`);
+        continue;
+      }
+
+      if (parameter.tag === 'returns') {
+        const type = parameter.type || 'unknown';
+        const description = parameter.description ? ` — ${parameter.description}` : '';
+        lines.push(`- **Returns:** \`${type}\`${description}`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  if (page.typeDeclarations?.trim()) {
+    lines.push('## Type Declarations');
+    lines.push('');
+    lines.push(createCodeFence('ts', page.typeDeclarations));
+    lines.push('');
+  }
+
+  if (page.demo?.trim()) {
+    lines.push('## Demo');
+    lines.push('');
+    lines.push(createCodeFence('tsx', page.demo));
+    lines.push('');
+  }
+
+  const { hooks, utils, packages } = page.dependencies;
+  if (hooks.length || utils.length || packages.length) {
+    lines.push('## Dependencies');
+    lines.push('');
+    if (hooks.length) {
+      lines.push(`- **Hooks:** ${hooks.map((item) => `\`${item}\``).join(', ')}`);
+    }
+    if (utils.length) {
+      lines.push(`- **Utils:** ${utils.map((item) => `\`${item}\``).join(', ')}`);
+    }
+    if (packages.length) {
+      lines.push(`- **Packages:** ${packages.map((item) => `\`${item}\``).join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
 };
 
 const createHtmlCode = async (code: string, language: CodeLanguage) =>
@@ -321,10 +467,10 @@ const init = async () => {
 
   const metadata = await Promise.all(
     content.map(async (element) => {
-      const content = await getContentFile(element.type, element.name);
+      const source = await getContentFile(element.type, element.name);
       const extension = await getExtensionFile(element.type, element.name);
 
-      const jsdocMatch = matchJsdoc(content);
+      const jsdocMatch = matchJsdoc(source);
 
       if (!jsdocMatch) {
         console.error(`No jsdoc comment found for ${element.name}`);
@@ -365,18 +511,23 @@ const init = async () => {
         extension
       );
 
-      const sourceFile = ts.createSourceFile('temp.ts', content, ts.ScriptTarget.Latest, true);
-      const typeDeclarations = extractTypeInfo(sourceFile);
+      const sourceFile = ts.createSourceFile('temp.ts', source, ts.ScriptTarget.Latest, true);
+      const typeDeclarationsSource = extractTypeInfo(sourceFile);
+      const dependencies = extractDependencies(source);
+      const demoSource = isDemo
+        ? await fs.promises.readFile(
+            path.join(CORE_ROOT, `${element.type}s`, element.name, `${element.name}.demo.tsx`),
+            'utf-8'
+          )
+        : undefined;
 
-      const dependencies = extractDependencies(content);
-
-      return {
+      const page = {
         badges: {
           firstCommitAt: new Date(firstCommitAt).getTime(),
           isNew,
           lastCommitAt: new Date(lastCommitAt).getTime()
         },
-        code: await createHtmlCode(content, 'tsx'),
+        code: await createHtmlCode(source, 'tsx'),
         id: element.name,
         isTest,
         isDemo,
@@ -392,25 +543,47 @@ const init = async () => {
         lastModified: lastCommitAt,
         examples: jsdoc.examples.map((example) => example.description),
         apiParameters: jsdoc.apiParameters ?? [],
-        ...(typeDeclarations && {
-          typeDeclarations: await createHtmlCode(typeDeclarations, 'tsx')
+        ...(typeDeclarationsSource && {
+          typeDeclarations: await createHtmlCode(typeDeclarationsSource, 'tsx')
         }),
         dependencies,
         contributors,
-        ...(isDemo && {
-          demo: await createHtmlCode(
-            await fs.promises.readFile(
-              path.join(CORE_ROOT, `${element.type}s`, element.name, `${element.name}.demo.tsx`),
-              'utf-8'
-            ),
-            'tsx'
-          )
+        ...(demoSource && {
+          demo: await createHtmlCode(demoSource, 'tsx')
         })
       };
+
+      const share: ShareMarkdownPage = {
+        name: page.name,
+        type: page.type,
+        description: page.description,
+        category: page.category,
+        usage: page.usage,
+        isTest: page.isTest,
+        examples: page.examples,
+        apiParameters: page.apiParameters,
+        dependencies: page.dependencies,
+        source,
+        ...(page.warning && { warning: page.warning }),
+        ...(page.browserapi && {
+          browserapi: {
+            name: page.browserapi.name,
+            description: page.browserapi.description
+          }
+        }),
+        ...(typeDeclarationsSource && { typeDeclarations: typeDeclarationsSource }),
+        ...(demoSource && { demo: demoSource })
+      };
+
+      return { page, share };
     })
   );
 
-  const pages = metadata.filter(Boolean) as unknown as FunctionMetadata[];
+  const generated = metadata.filter(Boolean) as {
+    page: FunctionMetadata;
+    share: ShareMarkdownPage;
+  }[];
+  const pages = generated.map(({ page }) => page);
   const testCoverage = pages.reduce((acc, page) => acc + Number(page.isTest), 0);
 
   console.log('\nElements injection report\n');
@@ -434,7 +607,7 @@ const init = async () => {
 
   console.log('\n[generate-functions] Writing files...');
 
-  for (const page of pages) {
+  for (const { page, share } of generated) {
     const mdx = createMdxTemplate(page);
     await fs.promises.writeFile(
       path.join(CONTENT_ROOT, 'functions', `${page.type}s`, `${page.name}.mdx`),
@@ -447,6 +620,15 @@ const init = async () => {
       JSON.stringify(page, null, 2),
       'utf-8'
     );
+
+    const shareMarkdownPath = path.join(
+      PUBLIC_ROOT,
+      'functions',
+      `${page.type}s`,
+      `${page.name}.md`
+    );
+    await fs.promises.mkdir(path.dirname(shareMarkdownPath), { recursive: true });
+    await fs.promises.writeFile(shareMarkdownPath, createShareMarkdown(share), 'utf-8');
 
     if (page.demo) {
       const demo = await createDemo(page);
@@ -465,6 +647,18 @@ const init = async () => {
       metaJson,
       'utf-8'
     );
+
+    const shareDirectory = path.join(PUBLIC_ROOT, 'functions', `${type}s`);
+    const keep = new Set(
+      pages.filter((page) => page.type === type).map((page) => `${page.name}.md`)
+    );
+
+    if (!fs.existsSync(shareDirectory)) continue;
+
+    for (const file of await fs.promises.readdir(shareDirectory)) {
+      if (!file.endsWith('.md') || keep.has(file)) continue;
+      await fs.promises.unlink(path.join(shareDirectory, file));
+    }
   }
 
   const functionsMd = createFunctionsMd(pages);

--- a/packages/newdocs/scripts/generate-static.ts
+++ b/packages/newdocs/scripts/generate-static.ts
@@ -13,6 +13,11 @@ const init = () => {
   for (const file of files) {
     if (typeof file !== 'string' || !file.endsWith('.mdx')) continue;
 
+    // Function pages get a resolved markdown export from generate-functions.
+    // Copying the MDX shell would replace AI-ready content with internals.
+    const normalized = file.replaceAll('\\', '/');
+    if (normalized.startsWith('functions/')) continue;
+
     const sourcePath = path.join(CONTENT_ROOT, file);
     const targetPath = path.join(PUBLIC_ROOT, file.replace(/\.mdx$/i, '.md'));
 


### PR DESCRIPTION
## Дисклеймер

Сгенерировано ИИ, ревью от человека поверхностное + небольшие смоук-тесты.

Для референса брался [shadcn/ui](https://ui.shadcn.com) (Copy Page / View as Markdown / resolved page content).

Дальше от ИИ:

---

## ⚠️ Автоген не в этом PR

В PR **только код** (`generate-functions`, `generate-static`, `page.tsx`).

Массовый diff `public/functions/**/*.md` (~177 файлов) **не включён**, чтобы ревью было читаемым.

После ревью — автоген поверх или отдельным follow-up.

## Зачем
На страницах функций **Copy Page** копировал внутренний MDX-shell, а не документацию. Текст почти бесполезен для AI и шаринга. Тот же shell отдавался как View as Markdown.

Нужен один resolved markdown-артефакт на функцию: полезный контент, порядок секций как на странице (в духе shadcn).

Closes #494

## Что сделано
1. Генерация share-markdown в `generate-functions` (plain source/types/demo/API → md).
2. `generate-static` не перезаписывает `public/functions/**` MDX-shell'ами.
3. Copy Page читает `public/functions/{hooks|helpers}/{name}.md` вместо `getText('raw')`.
4. Запись share-md в `public/functions/**` заложена в генераторе (сами файлы — follow-up / автоген после ревью).

Структура md (как страница):
- demo-код сверху (без отдельного `## Demo`)
- `## Installation` — library, CLI, manual + source
- `## Usage`
- `## Type Declarations`
- `## API` — таблицы Parameters / Returns (как `FunctionApi`), overloads
- `## Contributors`

## Как проверить
- `/functions/hooks/useCopy.md` — секции как на странице, есть source/API-таблица, нет `import metadata`
- Copy Page на `/functions/hooks/useCopy` — тот же текст, что `.md`
- `useActiveElement.md` — overload-группы в API
- `pnpm run generate:static` не затирает share-md

## Верификация

### Что смотрели
- Контракт кода: `createShareMarkdown` / `createShareApiMarkdown`, `createMdxTemplate`, `function-api.tsx`, `page.tsx`, `generate-static` skip
- Артефакты: все **177** `public/functions/**/*.md` (shell-маркеры, banned H2, parity mdx↔md, API-таблицы, fences)
- Сэмплы: `useCopy`, `useActiveElement` (overloads), `useQuery` (богатый API), helpers (`cn`, `createContext`), warning (`useOnce`), returns-only / no-API
- Live: `pnpm dev :4000` — curl HTML + `.md`, Playwright outlines H2/H3, RSC payload Copy Page == disk `.md`
- Ранее: E2E Copy Page через intercept `clipboard.writeText` (resolved md, не shell)

### Как
- **Статика:** `rg` по shell/H2, сверка outline, сравнение с MDX/meta
- **Live HTTP:** curl 200 + body
- **Браузер:** Playwright — headings страницы vs md; payload copy в props/RSC
- **Регрессия:** `generate:static` не clobber'ит share-md

### Итог проверки
**PASS WITH GAPS** — match со страницей достаточный; blockers нет.

### Несоответствия page ↔ md (не правили)
- **Installation:** на UI табы, в md подряд bash / bash / manual+source — табы это UI-хром; в markdown линейный flatten (как shadcn). Контент тот же.
- **Demo:** live banner на UI, в md только raw `*.demo.tsx` без `## Demo` — интерактив в clipboard не переносится; source demo = shadcn-подход с ComponentPreview. Отдельного `## Demo` на странице нет.
- **Returns:** в md часто + description из JSDoc, на UI в `FunctionApi` в основном type — description уже в данных; для AI полезнее. Строгий 1:1 с UI не критичен.
- **Header badges** (category / usage / test) не в body md — часть frontmatter/хрома страницы, не секции TOC.
- **Demo UI** может показывать свои H2/H3 («Account settings» и т.п.) — содержимое демо-компонента, не outline docs; в md остаётся внутри code fence.

### Не автоматизировано в последнем прогоне
- Headless click → system clipboard (в одном прогоне intercept DOM click не сработал; идентичность copy доказана через RSC props == `.md`)

## Коммиты
- `fix(docs): resolve function Copy Page from share markdown`
- `fix(docs): align share markdown sections with function page`
- `fix(docs): render share markdown API as tables`
- `fix(docs): use tsx fences in function share markdown`

Автоген `public/functions/**` в PR не входит (см. секцию выше).

## Зачем каждое изменение

### `packages/newdocs/scripts/generate-functions.ts`
**Зачем:** единственное место с plain source, types, demo и JSDoc API до Shiki/HTML.  
**Почему так:** UI остаётся MDX + meta; для Copy/AI нужен линейный md. Build-time generation = пайплайн репо, без runtime-резолва JSX.  
**Что внутри:**
- `createShareMarkdown` — порядок секций как у страницы
- `createShareApiMarkdown` — таблицы API как `FunctionApi`
- запись в `public/functions/...`, prune stale shells
- fences: `tsx` / `bash`

### `packages/newdocs/scripts/generate-static.ts`
**Зачем:** раньше копировал весь `content/**/*.mdx` → `public/**/*.md`, в т.ч. function shells.  
**Почему обязательно:** идёт после `generate-functions` и без skip затирал resolved md.  
**Что внутри:** skip `functions/`.

### `packages/newdocs/app/(docs)/functions/[[...slug]]/page.tsx`
**Зачем:** сюда приходит строка для Copy Page.  
**Почему так:** `FunctionHeader` уже делает `copy(markdown)`; меняем источник на тот же файл, что и `.md` URL → Copy и View as Markdown не расходятся.  
**Что внутри:** `readFile(public/functions/{type}s/{name}.md)` вместо `getText('raw')`.

### `packages/newdocs/public/functions/**/*.md` (не в этом PR)
**Зачем:** resolved share-md для Copy Page / View as Markdown (tracked gen в репо).  
**Почему не здесь:** ~177 файлов зашумляют diff; после ревью — автоген поверх или отдельным follow-up.

