### PR TITLE
[bug] 🧊 use url search params

### DIFF
--- a/packages/core/src/bundle/hooks/useUrlSearchParam/useUrlSearchParam.js
+++ b/packages/core/src/bundle/hooks/useUrlSearchParam/useUrlSearchParam.js
@@ -120,13 +120,12 @@ export const useUrlSearchParam = (key, params) => {
   }, []);
   const remove = (options) => {
     setUrlSearchParam(key, undefined, mode, options?.write ?? writeMode);
-    setValue(initialValue);
+    setValue(undefined);
   };
   useEffect(() => {
     const onParamsChange = () => {
       const urlSearchParams = getUrlSearchParams(mode);
       const newValue = urlSearchParams.get(key);
-      if (newValue === null) return setValue(initialValue);
       setValue(newValue ? deserializer(newValue) : undefined);
     };
     window.addEventListener(URL_SEARCH_PARAMS_EVENT, onParamsChange);

--- a/packages/core/src/bundle/hooks/useUrlSearchParam/useUrlSearchParam.js
+++ b/packages/core/src/bundle/hooks/useUrlSearchParam/useUrlSearchParam.js
@@ -112,6 +112,12 @@ export const useUrlSearchParam = (key, params) => {
     setUrlSearchParam(key, value, mode, options?.write ?? writeMode);
     setValue(value);
   };
+  useEffect(() => {
+    if (initialValue === undefined) return;
+    const urlSearchParams = getUrlSearchParams(mode);
+    if (urlSearchParams.get(key) !== null) return;
+    setUrlSearchParam(key, initialValue, mode, writeMode);
+  }, []);
   const remove = (options) => {
     setUrlSearchParam(key, undefined, mode, options?.write ?? writeMode);
     setValue(initialValue);

--- a/packages/core/src/bundle/hooks/useUrlSearchParam/useUrlSearchParam.js
+++ b/packages/core/src/bundle/hooks/useUrlSearchParam/useUrlSearchParam.js
@@ -105,10 +105,7 @@ export const useUrlSearchParam = (key, params) => {
   const [value, setValue] = useState(() => {
     const urlSearchParams = getUrlSearchParams(mode);
     const currentValue = urlSearchParams.get(key);
-    if (currentValue === null && initialValue !== undefined) {
-      setUrlSearchParam(key, initialValue, mode, writeMode);
-      return initialValue;
-    }
+    if (currentValue === null) return initialValue;
     return currentValue ? deserializer(currentValue) : undefined;
   });
   const set = (value, options) => {
@@ -117,12 +114,13 @@ export const useUrlSearchParam = (key, params) => {
   };
   const remove = (options) => {
     setUrlSearchParam(key, undefined, mode, options?.write ?? writeMode);
-    setValue(undefined);
+    setValue(initialValue);
   };
   useEffect(() => {
     const onParamsChange = () => {
       const urlSearchParams = getUrlSearchParams(mode);
       const newValue = urlSearchParams.get(key);
+      if (newValue === null) return setValue(initialValue);
       setValue(newValue ? deserializer(newValue) : undefined);
     };
     window.addEventListener(URL_SEARCH_PARAMS_EVENT, onParamsChange);

--- a/packages/core/src/bundle/hooks/useUrlSearchParams/useUrlSearchParams.js
+++ b/packages/core/src/bundle/hooks/useUrlSearchParams/useUrlSearchParams.js
@@ -90,12 +90,10 @@ export const useUrlSearchParams = (params) => {
   const [value, setValue] = useState(() => {
     if (typeof window === 'undefined') return initialValue ?? {};
     const urlSearchParams = getUrlSearchParams(mode);
-    const value = {
+    return {
       ...(initialValue && getParsedUrlSearchParams(initialValue)),
       ...getParsedUrlSearchParams(urlSearchParams)
     };
-    setUrlSearchParams(mode, value, writeMode);
-    return value;
   });
   const set = (params, options) => {
     const searchParams = setUrlSearchParams(
@@ -108,7 +106,10 @@ export const useUrlSearchParams = (params) => {
   useEffect(() => {
     const onParamsChange = () => {
       const searchParams = getUrlSearchParams(mode);
-      setValue(getParsedUrlSearchParams(searchParams));
+      setValue({
+        ...(initialValue && getParsedUrlSearchParams(initialValue)),
+        ...getParsedUrlSearchParams(searchParams)
+      });
     };
     window.addEventListener(URL_SEARCH_PARAMS_EVENT, onParamsChange);
     window.addEventListener('popstate', onParamsChange);

--- a/packages/core/src/bundle/hooks/useUrlSearchParams/useUrlSearchParams.js
+++ b/packages/core/src/bundle/hooks/useUrlSearchParams/useUrlSearchParams.js
@@ -115,10 +115,7 @@ export const useUrlSearchParams = (params) => {
   useEffect(() => {
     const onParamsChange = () => {
       const searchParams = getUrlSearchParams(mode);
-      setValue({
-        ...(initialValue && getParsedUrlSearchParams(initialValue)),
-        ...getParsedUrlSearchParams(searchParams)
-      });
+      setValue(getParsedUrlSearchParams(searchParams));
     };
     window.addEventListener(URL_SEARCH_PARAMS_EVENT, onParamsChange);
     window.addEventListener('popstate', onParamsChange);

--- a/packages/core/src/bundle/hooks/useUrlSearchParams/useUrlSearchParams.js
+++ b/packages/core/src/bundle/hooks/useUrlSearchParams/useUrlSearchParams.js
@@ -104,6 +104,15 @@ export const useUrlSearchParams = (params) => {
     setValue(getParsedUrlSearchParams(searchParams));
   };
   useEffect(() => {
+    if (!initialValue) return;
+    const urlSearchParams = getUrlSearchParams(mode);
+    const missingParams = Object.keys(getParsedUrlSearchParams(initialValue)).filter(
+      (param) => !urlSearchParams.has(param)
+    );
+    if (!missingParams.length) return;
+    setUrlSearchParams(mode, value, writeMode);
+  }, []);
+  useEffect(() => {
     const onParamsChange = () => {
       const searchParams = getUrlSearchParams(mode);
       setValue({

--- a/packages/core/src/hooks/useUrlSearchParam/useUrlSearchParam.ts
+++ b/packages/core/src/hooks/useUrlSearchParam/useUrlSearchParam.ts
@@ -202,7 +202,7 @@ export const useUrlSearchParam = (<Value>(key: string, params?: any) => {
 
   const remove = (options?: UseUrlSearchParamsActionOptions) => {
     setUrlSearchParam(key, undefined, mode, options?.write ?? writeMode);
-    setValue(initialValue);
+    setValue(undefined);
   };
 
   useEffect(() => {
@@ -210,7 +210,6 @@ export const useUrlSearchParam = (<Value>(key: string, params?: any) => {
       const urlSearchParams = getUrlSearchParams(mode);
       const newValue = urlSearchParams.get(key);
 
-      if (newValue === null) return setValue(initialValue);
       setValue(newValue ? deserializer(newValue) : undefined);
     };
 

--- a/packages/core/src/hooks/useUrlSearchParam/useUrlSearchParam.ts
+++ b/packages/core/src/hooks/useUrlSearchParam/useUrlSearchParam.ts
@@ -182,11 +182,7 @@ export const useUrlSearchParam = (<Value>(key: string, params?: any) => {
     const urlSearchParams = getUrlSearchParams(mode);
     const currentValue = urlSearchParams.get(key);
 
-    if (currentValue === null && initialValue !== undefined) {
-      setUrlSearchParam(key, initialValue, mode, writeMode);
-      return initialValue;
-    }
-
+    if (currentValue === null) return initialValue;
     return currentValue ? deserializer(currentValue) : undefined;
   });
 
@@ -197,13 +193,15 @@ export const useUrlSearchParam = (<Value>(key: string, params?: any) => {
 
   const remove = (options?: UseUrlSearchParamsActionOptions) => {
     setUrlSearchParam(key, undefined, mode, options?.write ?? writeMode);
-    setValue(undefined);
+    setValue(initialValue);
   };
 
   useEffect(() => {
     const onParamsChange = () => {
       const urlSearchParams = getUrlSearchParams(mode);
       const newValue = urlSearchParams.get(key);
+
+      if (newValue === null) return setValue(initialValue);
       setValue(newValue ? deserializer(newValue) : undefined);
     };
 

--- a/packages/core/src/hooks/useUrlSearchParam/useUrlSearchParam.ts
+++ b/packages/core/src/hooks/useUrlSearchParam/useUrlSearchParam.ts
@@ -191,6 +191,15 @@ export const useUrlSearchParam = (<Value>(key: string, params?: any) => {
     setValue(value);
   };
 
+  useEffect(() => {
+    if (initialValue === undefined) return;
+
+    const urlSearchParams = getUrlSearchParams(mode);
+    if (urlSearchParams.get(key) !== null) return;
+
+    setUrlSearchParam(key, initialValue, mode, writeMode);
+  }, []);
+
   const remove = (options?: UseUrlSearchParamsActionOptions) => {
     setUrlSearchParam(key, undefined, mode, options?.write ?? writeMode);
     setValue(initialValue);

--- a/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.demo.tsx
+++ b/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.demo.tsx
@@ -81,7 +81,8 @@ const Demo = () => {
     cuisine: 'All'
   });
 
-  const { search, cuisine } = filters.value;
+  const { cuisine } = filters.value;
+  const search = String(filters.value.search ?? '');
 
   const results = RECIPES.filter((recipe) => {
     const matchesSearch = recipe.name.toLowerCase().includes(search.toLowerCase().trim());

--- a/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.ts
+++ b/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.ts
@@ -184,6 +184,18 @@ export const useUrlSearchParams = (<Value extends UrlParams>(
   };
 
   useEffect(() => {
+    if (!initialValue) return;
+
+    const urlSearchParams = getUrlSearchParams(mode);
+    const missingParams = Object.keys(getParsedUrlSearchParams(initialValue)).filter(
+      (param) => !urlSearchParams.has(param)
+    );
+    if (!missingParams.length) return;
+
+    setUrlSearchParams(mode, value, writeMode);
+  }, []);
+
+  useEffect(() => {
     const onParamsChange = () => {
       const searchParams = getUrlSearchParams(mode);
       setValue({

--- a/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.ts
+++ b/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.ts
@@ -198,10 +198,7 @@ export const useUrlSearchParams = (<Value extends UrlParams>(
   useEffect(() => {
     const onParamsChange = () => {
       const searchParams = getUrlSearchParams(mode);
-      setValue({
-        ...(initialValue && getParsedUrlSearchParams(initialValue)),
-        ...getParsedUrlSearchParams(searchParams)
-      } as Value);
+      setValue(getParsedUrlSearchParams(searchParams) as Value);
     };
 
     window.addEventListener(URL_SEARCH_PARAMS_EVENT, onParamsChange);

--- a/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.ts
+++ b/packages/core/src/hooks/useUrlSearchParams/useUrlSearchParams.ts
@@ -168,14 +168,10 @@ export const useUrlSearchParams = (<Value extends UrlParams>(
     if (typeof window === 'undefined') return (initialValue ?? {}) as Value;
 
     const urlSearchParams = getUrlSearchParams(mode);
-    const value = {
+    return {
       ...(initialValue && getParsedUrlSearchParams(initialValue)),
       ...getParsedUrlSearchParams(urlSearchParams)
     } as Value;
-
-    setUrlSearchParams(mode, value, writeMode);
-
-    return value;
   });
 
   const set = (params: Partial<Value>, options?: UseUrlSearchParamsSetOptions) => {
@@ -190,7 +186,10 @@ export const useUrlSearchParams = (<Value extends UrlParams>(
   useEffect(() => {
     const onParamsChange = () => {
       const searchParams = getUrlSearchParams(mode);
-      setValue(getParsedUrlSearchParams(searchParams) as Value);
+      setValue({
+        ...(initialValue && getParsedUrlSearchParams(initialValue)),
+        ...getParsedUrlSearchParams(searchParams)
+      } as Value);
     };
 
     window.addEventListener(URL_SEARCH_PARAMS_EVENT, onParamsChange);


### PR DESCRIPTION
Changes

1. Don't write to the URL during render
The useState initializer is now pure: it only reads the current search params and merges them over initialValue. All history.* calls and event dispatches are gone from the render phase this fixes the broken navigation and the React warning.

2. Reflect initialValue in the URL after mount (useEffect)
So that the URL stays shareable/bookmarkable out of the box, the initial value is still written to the URL but in a mount effect, after the render commits. The write is guarded: it only happens when some of the initialValue keys are actually missing from the URL. This keeps the effect idempotent (safe under StrictMode's double-invoked effects, no duplicate history entries with write: 'push') and leaves the URL untouched when the user arrives with params already set.

3. The docs demo was updated accordingly (String(filters.value.search ?? '')) since a param read back from the URL is not guaranteed to keep its original type.