### PR TITLE
🧊 fix(useTimer): prevent the timer from going negative when crossing zero

### DIFF
--- a/packages/core/src/bundle/hooks/useTimer/useTimer.js
+++ b/packages/core/src/bundle/hooks/useTimer/useTimer.js
@@ -67,9 +67,10 @@ export const useTimer = (...params) => {
       setSeconds((prevSeconds) => {
         optionsRef.current?.onTick?.(prevSeconds);
         const updatedSeconds = prevSeconds - 1;
-        if (updatedSeconds === 0) {
+        if (updatedSeconds <= 0) {
           setActive(false);
           optionsRef.current?.onExpire?.();
+          return 0;
         }
         return updatedSeconds;
       });

--- a/packages/core/src/hooks/useTimer/useTimer.test.ts
+++ b/packages/core/src/hooks/useTimer/useTimer.test.ts
@@ -347,3 +347,26 @@ it('Should accept callback as second parameter', () => {
 
   expect(callback).toHaveBeenCalledOnce();
 });
+
+it('Should expire fractional initial seconds without going negative', () => {
+  const { result } = renderHook(() => useTimer(2.5));
+
+  expect(result.current.count).toBe(2.5);
+
+  act(() => vi.advanceTimersToNextTimer());
+  act(() => vi.advanceTimersToNextTimer());
+  act(() => vi.advanceTimersToNextTimer());
+
+  expect(result.current.active).toBeFalsy();
+  expect(result.current.count).toBe(0);
+});
+
+it('Should not go negative when a fractional value crosses zero mid-tick', () => {
+  const { result } = renderHook(() => useTimer(1));
+
+  act(() => result.current.restart(0.4));
+  act(() => vi.advanceTimersToNextTimer());
+
+  expect(result.current.active).toBeFalsy();
+  expect(result.current.count).toBe(0);
+});

--- a/packages/core/src/hooks/useTimer/useTimer.ts
+++ b/packages/core/src/hooks/useTimer/useTimer.ts
@@ -135,9 +135,10 @@ export const useTimer = ((...params: any[]) => {
       setSeconds((prevSeconds) => {
         optionsRef.current?.onTick?.(prevSeconds);
         const updatedSeconds = prevSeconds - 1;
-        if (updatedSeconds === 0) {
+        if (updatedSeconds <= 0) {
           setActive(false);
           optionsRef.current?.onExpire?.();
+          return 0;
         }
         return updatedSeconds;
       });


### PR DESCRIPTION
Fixes #501

Stop condition was strict `updatedSeconds === 0`. If the seconds count is fractional (e.g. `useTimer(2.5)` or `restart(0.4)`), the decrement-by-1 loop never lands exactly on `0` - `active` stays `true` forever and `count` runs negative indefinitely.

Changed to `updatedSeconds <= 0` with a clamp to `0`, matching the existing pattern already used in `decrease()`. Added 2 regression tests covering a fractional initial value and a fractional `restart()`.
