### PR TITLE
🧊  fix: useThrottleCallback bypasses throttle window after trailing call

### DIFF
--- a/packages/core/src/bundle/hooks/useThrottleCallback/useThrottleCallback.js
+++ b/packages/core/src/bundle/hooks/useThrottleCallback/useThrottleCallback.js
@@ -24,8 +24,10 @@ export const useThrottleCallback = (callback, delay) => {
   delayRef.current = delay;
   const throttled = useMemo(() => {
     const timer = () => {
-      isCalledRef.current = false;
-      if (!lastArgsRef.current) return;
+      if (!lastArgsRef.current) {
+        isCalledRef.current = false;
+        return;
+      }
       internalCallbackRef.current.apply(this, lastArgsRef.current);
       lastArgsRef.current = null;
       setTimeout(timer, delayRef.current);

--- a/packages/core/src/hooks/useThrottleCallback/useThrottleCallback.test.ts
+++ b/packages/core/src/hooks/useThrottleCallback/useThrottleCallback.test.ts
@@ -47,7 +47,12 @@ it('Should pass parameters into callback', () => {
   expect(callback).not.toHaveBeenCalledWith('second');
 
   act(() => vi.advanceTimersByTime(100));
+  expect(callback).toHaveBeenCalledWith('second');
+
   result.current('third');
+  expect(callback).not.toHaveBeenCalledWith('third');
+
+  act(() => vi.advanceTimersByTime(100));
   expect(callback).toHaveBeenCalledWith('third');
 });
 
@@ -64,6 +69,29 @@ it('Should use latest arguments for delayed call', () => {
 
   act(() => vi.advanceTimersByTime(100));
   expect(callback).toHaveBeenCalledWith('second');
+});
+
+it('Should keep throttling active while processing a trailing call', () => {
+  const callback = vi.fn();
+
+  const { result } = renderHook(() => useThrottleCallback(callback, 100));
+
+  result.current('a');
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  result.current('b');
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  act(() => vi.advanceTimersByTime(100));
+  expect(callback).toHaveBeenCalledTimes(2);
+  expect(callback).toHaveBeenLastCalledWith('b');
+
+  result.current('c');
+  expect(callback).toHaveBeenCalledTimes(2);
+
+  act(() => vi.advanceTimersByTime(100));
+  expect(callback).toHaveBeenCalledTimes(3);
+  expect(callback).toHaveBeenLastCalledWith('c');
 });
 
 it('Should return new function when delay changes', () => {

--- a/packages/core/src/hooks/useThrottleCallback/useThrottleCallback.ts
+++ b/packages/core/src/hooks/useThrottleCallback/useThrottleCallback.ts
@@ -34,9 +34,11 @@ export const useThrottleCallback = <Params extends unknown[], Return>(
 
   const throttled = useMemo(() => {
     const timer = () => {
-      isCalledRef.current = false;
+      if (!lastArgsRef.current) {
+        isCalledRef.current = false;
+        return;
+      }
 
-      if (!lastArgsRef.current) return;
       internalCallbackRef.current.apply(this, lastArgsRef.current);
       lastArgsRef.current = null;
       setTimeout(timer, delayRef.current);


### PR DESCRIPTION
Fixes #503

`timer()` reset `isCalledRef.current = false` unconditionally on every tick - including when it was about to fire a trailing call and reschedule. A call arriving right after that trailing call saw `isCalledRef === false` and fired immediately instead of queuing, breaking the once-per-delay guarantee.

Moved the reset into the` if (!lastArgsRef.current)` branch, matching the existing pattern already used in `throttle()` (utils/helpers/throttle.ts). `useThrottleState/useThrottleValue` inherit the fix since both wrap `useThrottleCallback`. Added a regression test covering a call right after a trailing invocation, and corrected an existing test that had asserted the buggy behavior.